### PR TITLE
chore: upgrade react-error-boundary to 6.1.0

### DIFF
--- a/packages/static/package.json
+++ b/packages/static/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@vitejs/plugin-rsc": "^0.5.14",
-    "react-error-boundary": "^6.0.3",
+    "react-error-boundary": "^6.1.0",
     "rsc-html-stream": "^0.0.7",
     "srvx": "^0.10.0"
   },

--- a/packages/static/src/client/error-boundary.tsx
+++ b/packages/static/src/client/error-boundary.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { startTransition } from "react";
-import { ErrorBoundary } from "react-error-boundary";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 
 /**
  * Whole-page error boundary for unexpected errors during development
@@ -14,12 +14,8 @@ export const GlobalErrorBoundary: React.FC<React.PropsWithChildren> = (
   );
 };
 
-interface FallbackProps {
-  error: Error;
-  resetErrorBoundary: () => void;
-}
-
 const Fallback: React.FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
+  const errorMessage = error instanceof Error ? error.message : String(error);
   return (
     <html>
       <head>
@@ -39,7 +35,7 @@ const Fallback: React.FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
       >
         <h1>Caught an unexpected error</h1>
         <p>See the console for details.</p>
-        <pre>Error: {error.message}</pre>
+        <pre>Error: {errorMessage}</pre>
         <button
           onClick={() => {
             startTransition(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,8 +116,8 @@ importers:
         specifier: ^0.5.14
         version: 0.5.14(react-dom@19.2.3(react@19.2.3))(react-server-dom-webpack@19.2.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1))(react@19.2.3)(vite@7.3.1(@types/node@25.0.9)(terser@5.46.0))
       react-error-boundary:
-        specifier: ^6.0.3
-        version: 6.0.3(react@19.2.3)
+        specifier: ^6.1.0
+        version: 6.1.0(react@19.2.3)
       rsc-html-stream:
         specifier: ^0.0.7
         version: 0.0.7
@@ -1516,8 +1516,8 @@ packages:
     peerDependencies:
       react: ^19.2.3
 
-  react-error-boundary@6.0.3:
-    resolution: {integrity: sha512-5guqn2UYpCFjE8UDMA8J7Kke+YSGBFrKQRJb3XdcaGZXYINZfQXgBt3ifY6MvjkN7QROc5A8zclyoSCwrcRUKw==}
+  react-error-boundary@6.1.0:
+    resolution: {integrity: sha512-02k9WQ/mUhdbXir0tC1NiMesGzRPaCsJEWU/4bcFrbY1YMZOtHShtZP6zw0SJrBWA/31H0KT9/FgdL8+sPKgHA==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
@@ -3629,7 +3629,7 @@ snapshots:
       react: 19.2.3
       scheduler: 0.27.0
 
-  react-error-boundary@6.0.3(react@19.2.3):
+  react-error-boundary@6.1.0(react@19.2.3):
     dependencies:
       react: 19.2.3
 


### PR DESCRIPTION
Update FallbackProps to use the library's type directly instead of
defining a custom interface. Handle error as unknown type by safely
extracting the message.