### PR TITLE
fix(docs): add fallback="static" to Router component

### DIFF
--- a/packages/docs/src/App.tsx
+++ b/packages/docs/src/App.tsx
@@ -43,5 +43,5 @@ const routes: RouteDefinition[] = [
 ];
 
 export default function App() {
-  return <Router routes={routes} />;
+  return <Router routes={routes} fallback="static" />;
 }


### PR DESCRIPTION
This ensures the docs site handles routing fallback correctly for
static site generation.