### PR TITLE
refactor(static): simplify RSC payload path

### DIFF
--- a/packages/docs/src/pages/api/Defer.mdx
+++ b/packages/docs/src/pages/api/Defer.mdx
@@ -85,6 +85,6 @@ const routes = [
 
 By default, FUNSTACK Static puts the entire app (`<App />`) into one RSC payload (`/funstack__/index.txt`). The client fetches this payload to render your SPA.
 
-When you use `defer(<Component />)`, FUNSTACK Static creates **additional RSC payloads** for the rendering result of the element. This results in an additional emit of RSC payload files like `/funstack__/rsc/fun:rsc-payload/b5698be72eea3c37`.
+When you use `defer(<Component />)`, FUNSTACK Static creates **additional RSC payloads** for the rendering result of the element. This results in an additional emit of RSC payload files like `/funstack__/fun:rsc-payload/b5698be72eea3c37`.
 
 In the main RSC payload, the `defer` call is replaced with a client component `<ClientWrapper moduleId="fun:rsc-payload/b5698be72eea3c37" />`. This component is responsible for fetching the additional RSC payload from client and renders it when it's ready.

--- a/packages/static/src/rsc/rscModule.ts
+++ b/packages/static/src/rsc/rscModule.ts
@@ -11,7 +11,7 @@ export function getPayloadIDFor(rawId: string): string {
   return `${rscPayloadIDPrefix}${rawId}`;
 }
 
-const rscModulePathPrefix = "/funstack__/rsc/";
+const rscModulePathPrefix = "/funstack__/";
 const rscModulePathSuffix = ".txt";
 
 export function getModulePathFor(id: string): string {


### PR DESCRIPTION
## Summary
- Remove redundant `rsc` directory from RSC payload paths
- Path changes from `funstack__/rsc/fun:rsc-payload/[hash].txt` to `funstack__/fun:rsc-payload/[hash].txt`
- Update documentation to reflect the new path structure

## Test plan
- [x] Build docs package with `pnpm turbo build --filter=docs`
- [x] Verify output structure shows `funstack__/fun:rsc-payload/` without `rsc/` subdirectory

🤖 Generated with [Claude Code](https://claude.com/claude-code)