### PR TITLE
Fix links in RSC documentation

### DIFF
--- a/packages/docs/src/pages/concepts/RSC.mdx
+++ b/packages/docs/src/pages/concepts/RSC.mdx
@@ -174,6 +174,6 @@ This makes FUNSTACK Static ideal for developers looking to leverage RSC benefits
 
 ## See Also
 
-- [Getting Started](/getting-started) - Set up your first project
-- [defer()](/api/defer) - Stream content progressively
-- [funstackStatic()](/api/funstack-static) - Plugin configuration
+- [Getting Started](/funstack-static/getting-started) - Set up your first project
+- [defer()](/funstack-static/api/defer) - Stream content progressively
+- [funstackStatic()](/funstack-static/api/funstack-static) - Plugin configuration


### PR DESCRIPTION
FUNSTACK Static のドキュメントありがとうございます！

concepts/rsc ページの See Also のリンクが開けなかったので、`packages/docs/src/pages/api/FunstackStatic.mdx`を参考に修正してみました（微修正です🙏）
