### PR TITLE
fix(docs): decode URL in GitHub Pages SPA redirect restoration

### DIFF
--- a/packages/docs/src/root.tsx
+++ b/packages/docs/src/root.tsx
@@ -50,8 +50,7 @@ export default function Root({ children }: { children: React.ReactNode }) {
 // See: https://github.com/rafgraph/spa-github-pages
 (function (l) {
   if (l.search[1] === "p") {
-    var decoded = l.search
-      .slice(3)
+    var decoded = decodeURIComponent(l.search.slice(3))
       .split("&")
       .map(function (s) {
         return s.replace(/~and~/g, "&");


### PR DESCRIPTION
The 404.html redirect script encodes the path with encodeURIComponent,
which turns slashes into %2F. The restoration script in root.tsx was
not decoding this, causing URLs like /learn%2Fhow-it-works instead of
/learn/how-it-works.