### PR TITLE
feat(defer): add options parameter with name field for debugging

### DIFF
--- a/packages/static/src/build/buildApp.ts
+++ b/packages/static/src/build/buildApp.ts
@@ -64,12 +64,12 @@ export async function buildApp(
   );
 
   // Write processed components with hash-based IDs
-  for (const { finalId, finalContent } of components) {
+  for (const { finalId, finalContent, name } of components) {
     const filePath = path.join(
       baseDir,
       getModulePathFor(finalId).replace(/^\//, ""),
     );
-    await writeFileNormal(filePath, finalContent, context);
+    await writeFileNormal(filePath, finalContent, context, name);
   }
 }
 
@@ -77,8 +77,10 @@ async function writeFileNormal(
   filePath: string,
   data: string,
   context: MinimalPluginContextWithoutEnvironment,
+  name?: string,
 ) {
   await mkdir(path.dirname(filePath), { recursive: true });
-  context.info(`[funstack] Writing ${filePath}`);
+  const nameInfo = name ? ` (${name})` : "";
+  context.info(`[funstack] Writing ${filePath}${nameInfo}`);
   await writeFile(filePath, data);
 }

--- a/packages/static/src/build/rscProcessor.ts
+++ b/packages/static/src/build/rscProcessor.ts
@@ -6,6 +6,7 @@ import { findReferencedIds, topologicalSort } from "./dependencyGraph";
 export interface ProcessedComponent {
   finalId: string;
   finalContent: string;
+  name?: string;
 }
 
 export interface ProcessResult {
@@ -17,6 +18,7 @@ export interface ProcessResult {
 interface RawComponent {
   id: string;
   data: string;
+  name?: string;
 }
 
 /**
@@ -33,8 +35,10 @@ export async function processRscComponents(
 ): Promise<ProcessResult> {
   // Step 1: Collect all components from deferRegistry
   const components = new Map<string, string>();
-  for await (const { id, data } of deferRegistryIterator) {
+  const componentNames = new Map<string, string | undefined>();
+  for await (const { id, data, name } of deferRegistryIterator) {
     components.set(id, data);
+    componentNames.set(id, name);
   }
 
   // Step 2: Drain appRsc stream to string
@@ -99,6 +103,7 @@ export async function processRscComponents(
     processedComponents.push({
       finalId,
       finalContent: content,
+      name: componentNames.get(tempId),
     });
   }
 
@@ -116,6 +121,7 @@ export async function processRscComponents(
     processedComponents.push({
       finalId: tempId, // Keep original temp ID
       finalContent: content,
+      name: componentNames.get(tempId),
     });
   }
 

--- a/packages/static/src/entries/server.ts
+++ b/packages/static/src/entries/server.ts
@@ -1,1 +1,1 @@
-export { defer } from "../rsc/defer";
+export { defer, type DeferOptions } from "../rsc/defer";


### PR DESCRIPTION
Add a DeferOptions interface as the second parameter to the defer function.
The optional name field helps with debugging RSC payloads:
- Development: name is included in the payload file name
- Production: name is logged when the payload file is emitted