### PR TITLE
feat: add Playwright e2e tests for static plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,17 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @funstack/static exec playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: pnpm run test:e2e
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: packages/static/playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules
 dist
 .turbo
+
+# Playwright
+playwright-report/
+test-results/

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "turbo run dev",
     "test": "turbo run test",
     "test:run": "turbo run test:run",
+    "test:e2e": "turbo run test:e2e",
     "typecheck": "turbo run typecheck",
     "format": "prettier --write --experimental-cli .",
     "format:check": "prettier --check --experimental-cli ."

--- a/packages/static/e2e/fixture/package.json
+++ b/packages/static/e2e/fixture/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "e2e-fixture",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@funstack/static": "workspace:*",
+    "@types/react": "^19.2.10",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.6.1",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/packages/static/e2e/fixture/src/App.tsx
+++ b/packages/static/e2e/fixture/src/App.tsx
@@ -1,0 +1,11 @@
+import { Counter } from "./Counter";
+
+export default function App() {
+  return (
+    <main>
+      <h1>E2E Test App</h1>
+      <p data-testid="server-rendered">Server rendered content</p>
+      <Counter />
+    </main>
+  );
+}

--- a/packages/static/e2e/fixture/src/Counter.tsx
+++ b/packages/static/e2e/fixture/src/Counter.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { useState } from "react";
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+  return (
+    <button data-testid="counter" onClick={() => setCount((c) => c + 1)}>
+      Count: {count}
+    </button>
+  );
+}

--- a/packages/static/e2e/fixture/src/root.tsx
+++ b/packages/static/e2e/fixture/src/root.tsx
@@ -1,0 +1,11 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="UTF-8" />
+        <title>E2E Test Fixture</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/static/e2e/fixture/vite.config.ts
+++ b/packages/static/e2e/fixture/vite.config.ts
@@ -1,0 +1,13 @@
+import funstackStatic from "@funstack/static";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    funstackStatic({
+      root: "./src/root.tsx",
+      app: "./src/App.tsx",
+    }),
+    react(),
+  ],
+});

--- a/packages/static/e2e/playwright.config.ts
+++ b/packages/static/e2e/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+
+  use: {
+    baseURL: "http://localhost:4173",
+    trace: "on-first-retry",
+  },
+
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+
+  webServer: {
+    command:
+      "cd fixture && pnpm vite build && pnpm dlx serve -p 4173 dist/public",
+    url: "http://localhost:4173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/packages/static/e2e/tests/build.spec.ts
+++ b/packages/static/e2e/tests/build.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Build output verification", () => {
+  test("generates index.html with expected HTML structure", async ({
+    request,
+  }) => {
+    const response = await request.get("/");
+    expect(response.ok()).toBe(true);
+
+    const html = await response.text();
+
+    // Verify HTML structure
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("<html");
+    expect(html).toContain("lang=");
+    expect(html).toContain("<head>");
+    expect(html).toContain("<body>");
+
+    // Verify funstack static app entry marker is present (used for hydration)
+    expect(html).toContain("__FUNSTACK_APP_ENTRY__");
+    // Verify the RSC payload is preloaded
+    expect(html).toContain('rel="preload"');
+    expect(html).toContain("funstack__/fun:rsc-payload/");
+  });
+
+  test("generates RSC payload files at /funstack__/*.txt", async ({
+    request,
+  }) => {
+    // First get the index.html to find the RSC payload path
+    const indexResponse = await request.get("/");
+    const html = await indexResponse.text();
+
+    // Look for the RSC payload in preload link or FUNSTACK config
+    const rscPayloadMatch = html.match(
+      /funstack__\/fun:rsc-payload\/[^"'\s]+\.txt/,
+    );
+    expect(rscPayloadMatch).not.toBeNull();
+
+    const rscPayloadPath = "/" + rscPayloadMatch![0];
+    const rscResponse = await request.get(rscPayloadPath);
+    expect(rscResponse.ok()).toBe(true);
+
+    const rscPayload = await rscResponse.text();
+    // RSC payloads contain React Flight format data
+    expect(rscPayload.length).toBeGreaterThan(0);
+  });
+
+  test("generates JavaScript bundles in /assets/", async ({ request }) => {
+    const indexResponse = await request.get("/");
+    const html = await indexResponse.text();
+
+    // Look for dynamic import or script tags pointing to assets
+    const scriptMatch = html.match(/import\("\/assets\/([^"]+\.js)"\)/);
+    expect(scriptMatch).not.toBeNull();
+
+    // Extract and verify the script is loadable
+    const scriptPath = "/assets/" + scriptMatch![1];
+    const scriptResponse = await request.get(scriptPath);
+    expect(scriptResponse.ok()).toBe(true);
+  });
+});

--- a/packages/static/e2e/tests/hydration.spec.ts
+++ b/packages/static/e2e/tests/hydration.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Client-side hydration", () => {
+  test("renders server content", async ({ page }) => {
+    await page.goto("/");
+
+    // Verify server-rendered content is visible
+    await expect(page.locator("h1")).toHaveText("E2E Test App");
+    await expect(page.getByTestId("server-rendered")).toHaveText(
+      "Server rendered content",
+    );
+  });
+
+  test("client counter component hydrates and displays initial state", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const counter = page.getByTestId("counter");
+    await expect(counter).toBeVisible();
+    await expect(counter).toHaveText("Count: 0");
+  });
+
+  test("clicking counter button increments the count", async ({ page }) => {
+    await page.goto("/");
+
+    const counter = page.getByTestId("counter");
+
+    // Click and verify increment
+    await counter.click();
+    await expect(counter).toHaveText("Count: 1");
+
+    // Click again
+    await counter.click();
+    await expect(counter).toHaveText("Count: 2");
+
+    // Click multiple times
+    await counter.click();
+    await counter.click();
+    await expect(counter).toHaveText("Count: 4");
+  });
+
+  test("no JavaScript errors in console", async ({ page }) => {
+    const errors: string[] = [];
+
+    page.on("pageerror", (error) => {
+      errors.push(error.message);
+    });
+
+    await page.goto("/");
+
+    // Wait for hydration to complete by verifying counter is interactive
+    const counter = page.getByTestId("counter");
+    await counter.click();
+    await expect(counter).toHaveText("Count: 1");
+
+    expect(errors).toEqual([]);
+  });
+
+  test("RSC payload files are fetched", async ({ page }) => {
+    const rscRequests: string[] = [];
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (url.includes("funstack__/fun:rsc-payload/") && url.endsWith(".txt")) {
+        rscRequests.push(url);
+      }
+    });
+
+    await page.goto("/");
+
+    // Wait for page to fully load
+    await page.waitForLoadState("networkidle");
+
+    // At least one RSC payload should have been fetched
+    expect(rscRequests.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/static/package.json
+++ b/packages/static/package.json
@@ -40,11 +40,13 @@
     "dev": "tsdown --watch",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:e2e": "playwright test --config e2e/playwright.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "author": "uhyo <uhyo@uhy.ooo>",
   "license": "MIT",
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
     "@types/node": "catalog:",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",

--- a/packages/static/vitest.config.ts
+++ b/packages/static/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/__tests__/vitest.setup.ts"],
     globals: true,
+    exclude: ["**/node_modules/**", "**/e2e/**"],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
         specifier: ^0.10.1
         version: 0.10.1
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.58.0
       '@types/node':
         specifier: 'catalog:'
         version: 25.0.10
@@ -155,6 +158,30 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.0.10)(jsdom@27.4.0)(terser@5.46.0)
+
+  packages/static/e2e/fixture:
+    devDependencies:
+      '@funstack/static':
+        specifier: workspace:*
+        version: link:../..
+      '@types/react':
+        specifier: ^19.2.10
+        version: 19.2.10
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.10)
+      '@vitejs/plugin-react':
+        specifier: ^4.6.1
+        version: 4.7.0(vite@7.3.1(@types/node@25.0.10)(terser@5.46.0))
+      react:
+        specifier: 'catalog:'
+        version: 19.2.4
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.4(react@19.2.4)
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.1(@types/node@25.0.10)(terser@5.46.0)
 
 packages:
 
@@ -518,6 +545,11 @@ packages:
   '@oxc-project/types@0.110.0':
     resolution: {integrity: sha512-6Ct21OIlrEnFEJk5LT4e63pk3btsI6/TusD/GStLi7wYlGJNOl1GI9qvXAnRAxQU9zqA2Oz+UwhfTOU2rPZVow==}
 
+  '@playwright/test@1.58.0':
+    resolution: {integrity: sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
@@ -597,6 +629,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
@@ -838,6 +873,12 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitejs/plugin-react@5.1.2':
     resolution: {integrity: sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==}
@@ -1206,6 +1247,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1513,6 +1559,16 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  playwright-core@1.58.0:
+    resolution: {integrity: sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.0:
+    resolution: {integrity: sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1544,6 +1600,10 @@ packages:
     resolution: {integrity: sha512-02k9WQ/mUhdbXir0tC1NiMesGzRPaCsJEWU/4bcFrbY1YMZOtHShtZP6zw0SJrBWA/31H0KT9/FgdL8+sPKgHA==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
@@ -2400,6 +2460,10 @@ snapshots:
 
   '@oxc-project/types@0.110.0': {}
 
+  '@playwright/test@1.58.0':
+    dependencies:
+      playwright: 1.58.0
+
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
@@ -2444,6 +2508,8 @@ snapshots:
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
     optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
@@ -2665,6 +2731,18 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@25.0.10)(terser@5.46.0))':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 7.3.1(@types/node@25.0.10)(terser@5.46.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@25.0.10)(terser@5.46.0))':
     dependencies:
@@ -3096,6 +3174,9 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -3654,6 +3735,14 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  playwright-core@1.58.0: {}
+
+  playwright@1.58.0:
+    dependencies:
+      playwright-core: 1.58.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -3681,6 +3770,8 @@ snapshots:
   react-error-boundary@6.1.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  react-refresh@0.17.0: {}
 
   react-refresh@0.18.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - packages/*
+  - packages/static/e2e/fixture
 
 onlyBuiltDependencies:
   - esbuild

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,10 @@
     "typecheck": {
       "dependsOn": ["^build"],
       "outputs": []
+    },
+    "test:e2e": {
+      "dependsOn": ["^build"],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add Playwright-based end-to-end tests to verify the Vite plugin's core functionality
- Test fixture at `packages/static/e2e/fixture/` with minimal app using the plugin
- Build output tests verify HTML generation, RSC payloads, and JS bundles
- Hydration tests verify client-side interactivity and error-free operation
- CI integration with Playwright browser installation and artifact upload

## Test plan

- [x] `pnpm run test:run` - unit tests pass
- [x] `pnpm run test:e2e` - all 8 e2e tests pass locally
- [ ] CI workflow passes with new Playwright steps

🤖 Generated with [Claude Code](https://claude.ai/code)