### PR TITLE
ci: cache Playwright browsers to speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,18 @@ jobs:
         run: pnpm run build
 
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter @funstack/static exec playwright install-deps chromium
+
       - name: Install Playwright browsers
-        run: pnpm --filter @funstack/static exec playwright install --with-deps chromium
+        run: pnpm --filter @funstack/static exec playwright install chromium
 
       - name: Run e2e tests
         run: pnpm run test:e2e


### PR DESCRIPTION
## Summary
- Add GitHub Actions cache for Playwright browser binaries using `actions/cache@v4`
- Cache key based on OS and `pnpm-lock.yaml` hash to ensure invalidation on Playwright version changes

## Test plan
- [ ] First CI run shows cache miss and installs browsers normally
- [ ] Re-run CI workflow - second run shows cache hit with faster Playwright step

🤖 Generated with [Claude Code](https://claude.com/claude-code)