### PR TITLE
perf(docs): optimize shiki build by sharing highlighter singleton

### DIFF
--- a/packages/docs/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/docs/src/components/CodeBlock/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import { codeToHtml } from "shiki";
+import { getHighlighter, shikiThemes } from "../../lib/shiki";
 import styles from "./CodeBlock.module.css";
 
 interface CodeBlockProps {
@@ -10,12 +10,10 @@ export async function CodeBlock({
   children,
   language = "typescript",
 }: CodeBlockProps) {
-  const html = await codeToHtml(children.trim(), {
+  const highlighter = await getHighlighter();
+  const html = highlighter.codeToHtml(children.trim(), {
     lang: language,
-    themes: {
-      light: "github-light",
-      dark: "github-dark",
-    },
+    themes: shikiThemes,
   });
 
   return (

--- a/packages/docs/src/lib/shiki.ts
+++ b/packages/docs/src/lib/shiki.ts
@@ -1,0 +1,18 @@
+import { createHighlighter } from "shiki";
+
+let highlighterPromise: ReturnType<typeof createHighlighter> | null = null;
+
+export function getHighlighter() {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      themes: ["github-light", "github-dark"],
+      langs: ["typescript", "tsx", "bash"],
+    });
+  }
+  return highlighterPromise;
+}
+
+export const shikiThemes = {
+  light: "github-light",
+  dark: "github-dark",
+} as const;

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -1,32 +1,36 @@
 import funstackStatic from "@funstack/static";
 import mdx from "@mdx-js/rollup";
-import rehypeShiki from "@shikijs/rehype";
+import rehypeShikiFromHighlighter from "@shikijs/rehype/core";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type UserConfig } from "vite";
+import { getHighlighter, shikiThemes } from "./src/lib/shiki";
 
-export default defineConfig({
-  plugins: [
-    funstackStatic({
-      root: "./src/root.tsx",
-      app: "./src/App.tsx",
-    }),
-    {
-      enforce: "pre",
-      ...mdx({
-        rehypePlugins: [
-          [
-            rehypeShiki,
-            {
-              themes: {
-                light: "github-light",
-                dark: "github-dark",
-              },
-            },
-          ],
-        ],
+export default defineConfig(async () => {
+  const highlighter = await getHighlighter();
+
+  const config: UserConfig = {
+    plugins: [
+      funstackStatic({
+        root: "./src/root.tsx",
+        app: "./src/App.tsx",
       }),
-    },
-    react({ include: /\.(jsx|js|mdx|md|tsx|ts)$/ }),
-  ],
-  base: "/funstack-static/",
+      {
+        enforce: "pre",
+        ...mdx({
+          rehypePlugins: [
+            [
+              rehypeShikiFromHighlighter,
+              highlighter,
+              {
+                themes: shikiThemes,
+              },
+            ],
+          ],
+        }),
+      },
+      react({ include: /\.(jsx|js|mdx|md|tsx|ts)$/ }),
+    ],
+    base: "/funstack-static/",
+  };
+  return config;
 });


### PR DESCRIPTION
## Summary
- Create shared highlighter singleton in `packages/docs/src/lib/shiki.ts` that loads only 3 languages (typescript, tsx, bash) instead of 100+
- Update `vite.config.ts` to use `rehypeShikiFromHighlighter` from `@shikijs/rehype/core` with the shared instance
- Update `CodeBlock.tsx` to reuse the same highlighter instance

## Test plan
- [x] `pnpm --filter docs build` completes successfully
- [x] `pnpm --filter docs test` passes
- [ ] Verify syntax highlighting works on docs pages (both light/dark themes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)