### PR TITLE
refactor: rename ClientWrapper to DeferredComponent

### DIFF
--- a/packages/docs/src/pages/api/Defer.mdx
+++ b/packages/docs/src/pages/api/Defer.mdx
@@ -107,4 +107,4 @@ By default, FUNSTACK Static puts the entire app (`<App />`) into one RSC payload
 
 When you use `defer(<Component />)`, FUNSTACK Static creates **additional RSC payloads** for the rendering result of the element. This results in an additional emit of RSC payload files like `/funstack__/fun:rsc-payload/b5698be72eea3c37`. If you provide a `name` option, the file name will include it (e.g., `/funstack__/fun:rsc-payload/HomePage-b5698be72eea3c37`).
 
-In the main RSC payload, the `defer` call is replaced with a client component `<ClientWrapper moduleId="fun:rsc-payload/b5698be72eea3c37" />`. This component is responsible for fetching the additional RSC payload from client and renders it when it's ready.
+In the main RSC payload, the `defer` call is replaced with a client component `<DeferredComponent moduleId="fun:rsc-payload/b5698be72eea3c37" />`. This component is responsible for fetching the additional RSC payload from client and renders it when it's ready.

--- a/packages/static/src/rsc-client/clientWrapper.tsx
+++ b/packages/static/src/rsc-client/clientWrapper.tsx
@@ -12,11 +12,13 @@ export const RegistryContext = createContext<DeferRegistry | undefined>(
   undefined,
 );
 
-interface ClientWrapperProps {
+interface DeferredComponentProps {
   moduleID: string;
 }
 
-export const ClientWrapper: React.FC<ClientWrapperProps> = ({ moduleID }) => {
+export const DeferredComponent: React.FC<DeferredComponentProps> = ({
+  moduleID,
+}) => {
   const registry = use(RegistryContext);
   const modulePath = getModulePathFor(moduleID);
   if (registry) {

--- a/packages/static/src/rsc-client/entry.ts
+++ b/packages/static/src/rsc-client/entry.ts
@@ -1,3 +1,3 @@
 "use client";
 
-export { RegistryContext, ClientWrapper } from "./clientWrapper";
+export { RegistryContext, DeferredComponent } from "./clientWrapper";

--- a/packages/static/src/rsc/defer.tsx
+++ b/packages/static/src/rsc/defer.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from "react";
 import { renderToReadableStream } from "@vitejs/plugin-rsc/react/rsc";
-import { ClientWrapper } from "#rsc-client";
+import { DeferredComponent } from "#rsc-client";
 import { drainStream } from "../util/drainStream";
 import { getPayloadIDFor } from "./rscModule";
 
@@ -206,5 +206,5 @@ export function defer(
   const id = getPayloadIDFor(rawId);
   deferRegistry.register(element, id, name);
 
-  return <ClientWrapper moduleID={id} />;
+  return <DeferredComponent moduleID={id} />;
 }


### PR DESCRIPTION
## Summary

- Rename the internal `ClientWrapper` component to `DeferredComponent` to better reflect its role in handling deferred RSC payloads
- Update the props interface name accordingly (`ClientWrapperProps` → `DeferredComponentProps`)
- Update the documentation reference in `Defer.mdx`

## Test plan

- [ ] Verify TypeScript compilation passes
- [ ] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)