### PR TITLE
docs: fix incorrect import latency description

### DIFF
--- a/packages/docs/src/pages/learn/LazyServerComponents.mdx
+++ b/packages/docs/src/pages/learn/LazyServerComponents.mdx
@@ -25,7 +25,7 @@ export default function App() {
 }
 ```
 
-In a large application with many routes, this upfront loading adds latency to every request, even though only one route's component will actually render.
+In a large application with many routes, this upfront loading adds latency to the first request, even though only one route's component will actually render.
 
 While use of [defer()](./optimizing-payloads) helps reducing initial load by deferring _rendering_ of route components, the work to _import_ those components still happens immediately.
 


### PR DESCRIPTION
The latency from upfront module loading only impacts the first request,
not every request, because modules are cached after initial import.

https://claude.ai/code/session_01FQ6AZeMXDeW6qkfbMCehes