### PR TITLE
Add OGP meta tags to GitHub Pages 404.html

### DIFF
--- a/packages/docs/public/404.html
+++ b/packages/docs/public/404.html
@@ -2,7 +2,33 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Redirecting...</title>
+    <title>FUNSTACK Static - docs</title>
+    <meta
+      name="description"
+      content="FUNSTACK Static - A React framework without servers"
+    />
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="FUNSTACK Static - docs" />
+    <meta
+      property="og:description"
+      content="FUNSTACK Static - A React framework without servers"
+    />
+    <meta
+      property="og:image"
+      content="https://uhyo.github.io/funstack-static/FUNSTACK_Static_Hero_small.png"
+    />
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="FUNSTACK Static - docs" />
+    <meta
+      name="twitter:description"
+      content="FUNSTACK Static - A React framework without servers"
+    />
+    <meta
+      name="twitter:image"
+      content="https://uhyo.github.io/funstack-static/FUNSTACK_Static_Hero_small.png"
+    />
     <script>
       // GitHub Pages SPA redirect hack
       // This 404 page captures the current URL and redirects to index.html


### PR DESCRIPTION
Crawlers hitting non-existent URLs get served 404.html directly by
GitHub Pages (before the JS redirect runs), so they saw no social
preview. Add the same OG and Twitter Card meta tags used in root.tsx.

https://claude.ai/code/session_01Rnnm531pRQc6NW6j8C1SRc