### PR TITLE
feat(example): update example to use multiple entrypoints

### DIFF
--- a/packages/example/src/entries.tsx
+++ b/packages/example/src/entries.tsx
@@ -1,0 +1,16 @@
+import type { EntryDefinition } from "@funstack/static/entries";
+
+export default function getEntries(): EntryDefinition[] {
+  return [
+    {
+      path: "index.html",
+      root: () => import("./root"),
+      app: () => import("./pages/Home"),
+    },
+    {
+      path: "about.html",
+      root: () => import("./root"),
+      app: () => import("./pages/About"),
+    },
+  ];
+}

--- a/packages/example/src/pages/About.tsx
+++ b/packages/example/src/pages/About.tsx
@@ -1,0 +1,19 @@
+export default function About() {
+  return (
+    <div id="root">
+      <h1>About</h1>
+      <p>
+        This is an example application built with{" "}
+        <a href="https://github.com/anthropics/funstack-static">
+          FUNSTACK Static
+        </a>
+        , demonstrating multiple entrypoints for multi-page static site
+        generation with React Server Components.
+      </p>
+      <p>
+        Each page is defined as a separate entry in <code>src/entries.tsx</code>
+        , and gets its own HTML file during the build.
+      </p>
+    </div>
+  );
+}

--- a/packages/example/src/pages/Home.tsx
+++ b/packages/example/src/pages/Home.tsx
@@ -1,8 +1,8 @@
 import viteLogo from "/vite.svg";
-import reactLogo from "./assets/react.svg";
-import { ClientCounter } from "./client.tsx";
+import reactLogo from "../assets/react.svg";
+import { ClientCounter } from "../client.tsx";
 
-export default function App() {
+export default function Home() {
   return (
     <div id="root">
       <div>

--- a/packages/example/src/root.tsx
+++ b/packages/example/src/root.tsx
@@ -11,7 +11,9 @@ export default function Root({ children }: { children: React.ReactNode }) {
         <title>Vite + RSC</title>
       </head>
       <body>
-        <h1>My RSC Application</h1>
+        <nav>
+          <a href="/">Home</a> | <a href="/about">About</a>
+        </nav>
         <div className="app">{children}</div>
       </body>
     </html>

--- a/packages/example/vite.config.ts
+++ b/packages/example/vite.config.ts
@@ -5,8 +5,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   plugins: [
     funstackStatic({
-      root: "./src/root.tsx",
-      app: "./src/App.tsx",
+      entries: "./src/entries.tsx",
     }),
     react(),
   ],


### PR DESCRIPTION
Replace the single-entry root/app configuration with the new entries
API to demonstrate multi-page SSG. The example now generates both
index.html and about.html, with a shared root layout and navigation.

https://claude.ai/code/session_019WAWxXy4puJRQxvfc8bDNu