### PR TITLE
docs: add documentation for multiple entrypoints feature

### DIFF
--- a/packages/docs/src/App.tsx
+++ b/packages/docs/src/App.tsx
@@ -9,7 +9,9 @@ import LazyServerComponents from "./pages/learn/LazyServerComponents.mdx";
 import OptimizingPayloads from "./pages/learn/OptimizingPayloads.mdx";
 import RSCConcept from "./pages/learn/RSC.mdx";
 import DeferAndActivity from "./pages/learn/DeferAndActivity.mdx";
+import MultipleEntrypoints from "./pages/learn/MultipleEntrypoints.mdx";
 import SSR from "./pages/learn/SSR.mdx";
+import EntryDefinitionApi from "./pages/api/EntryDefinition.mdx";
 import FAQ from "./pages/FAQ.mdx";
 import GettingStarted from "./pages/GettingStarted.mdx";
 import MigratingFromViteSPA from "./pages/MigratingFromViteSPA.mdx";
@@ -63,6 +65,14 @@ const routes: RouteDefinition[] = [
         component: <Layout>{defer(<DeferApi />, { name: "DeferApi" })}</Layout>,
       }),
       route({
+        path: "/api/entry-definition",
+        component: (
+          <Layout>
+            {defer(<EntryDefinitionApi />, { name: "EntryDefinitionApi" })}
+          </Layout>
+        ),
+      }),
+      route({
         path: "/learn/how-it-works",
         component: (
           <Layout>{defer(<HowItWorks />, { name: "HowItWorks" })}</Layout>
@@ -95,6 +105,14 @@ const routes: RouteDefinition[] = [
         component: (
           <Layout>
             {defer(<DeferAndActivity />, { name: "DeferAndActivity" })}
+          </Layout>
+        ),
+      }),
+      route({
+        path: "/learn/multiple-entrypoints",
+        component: (
+          <Layout>
+            {defer(<MultipleEntrypoints />, { name: "MultipleEntrypoints" })}
           </Layout>
         ),
       }),

--- a/packages/docs/src/components/Sidebar/Sidebar.tsx
+++ b/packages/docs/src/components/Sidebar/Sidebar.tsx
@@ -45,6 +45,10 @@ export const navigation: NavSection[] = [
         href: "/funstack-static/learn/defer-and-activity",
       },
       {
+        label: "Multiple Entrypoints",
+        href: "/funstack-static/learn/multiple-entrypoints",
+      },
+      {
         label: "Server-Side Rendering",
         href: "/funstack-static/learn/ssr",
       },
@@ -58,6 +62,10 @@ export const navigation: NavSection[] = [
         href: "/funstack-static/api/funstack-static",
       },
       { label: "defer()", href: "/funstack-static/api/defer" },
+      {
+        label: "EntryDefinition",
+        href: "/funstack-static/api/entry-definition",
+      },
     ],
   },
   {

--- a/packages/docs/src/pages/GettingStarted.mdx
+++ b/packages/docs/src/pages/GettingStarted.mdx
@@ -177,4 +177,5 @@ This registers the `funstack-static-knowledge` skill, which provides your AI ass
 
 - Learn about the [funstackStatic() Plugin API](/funstack-static/api/funstack-static) for configuration options
 - Understand [defer()](/funstack-static/api/defer) for Server Component chunk splitting
+- Build multi-page static sites with [Multiple Entrypoints](/funstack-static/learn/multiple-entrypoints)
 - Dive into [React Server Components](/funstack-static/learn/rsc) concepts

--- a/packages/docs/src/pages/api/EntryDefinition.mdx
+++ b/packages/docs/src/pages/api/EntryDefinition.mdx
@@ -1,0 +1,139 @@
+# EntryDefinition
+
+The `EntryDefinition` type defines a single entry in a multi-page static site. Each entry produces one HTML file with its own RSC payload.
+
+## Import
+
+```typescript
+import type { EntryDefinition } from "@funstack/static/entries";
+```
+
+## Usage
+
+```tsx
+import type { EntryDefinition } from "@funstack/static/entries";
+
+export default function getEntries(): EntryDefinition[] {
+  return [
+    {
+      path: "index.html",
+      root: () => import("./root"),
+      app: () => import("./pages/Home"),
+    },
+    {
+      path: "about.html",
+      root: () => import("./root"),
+      app: () => import("./pages/About"),
+    },
+  ];
+}
+```
+
+## Type Definition
+
+```typescript
+interface EntryDefinition {
+  path: string;
+  root: MaybePromise<RootModule> | (() => MaybePromise<RootModule>);
+  app: ReactNode | MaybePromise<AppModule> | (() => MaybePromise<AppModule>);
+}
+
+type MaybePromise<T> = T | Promise<T>;
+type RootModule = {
+  default: React.ComponentType<{ children: React.ReactNode }>;
+};
+type AppModule = { default: React.ComponentType };
+```
+
+## Properties
+
+### path
+
+**Type:** `string`
+
+Output file path relative to the build output directory.
+
+- Must end with `.html`
+- Must not start with `/`
+- Duplicate paths cause a build error
+
+```typescript
+"index.html"; // -> /
+"about.html"; // -> /about
+"blog/post-1.html"; // -> /blog/post-1
+"blog/post-1/index.html"; // -> /blog/post-1/
+```
+
+### root
+
+**Type:** `MaybePromise<RootModule> | (() => MaybePromise<RootModule>)`
+
+The root component module. The module must have a `default` export of a component that accepts `{ children: React.ReactNode }`.
+
+```tsx
+// Lazy import (recommended)
+root: () => import("./root"),
+
+// Synchronous module object
+import Root from "./root";
+root: { default: Root },
+
+// Promise
+root: import("./root"),
+```
+
+Using lazy imports (`() => import(...)`) is recommended to keep memory usage low when generating many entries.
+
+### app
+
+**Type:** `ReactNode | MaybePromise<AppModule> | (() => MaybePromise<AppModule>)`
+
+The app content for this entry. Accepts three forms:
+
+**Module (sync or lazy)** -- the module must have a `default` export component:
+
+```tsx
+// Lazy import
+app: () => import("./pages/Home"),
+
+// Synchronous module
+import Home from "./pages/Home";
+app: { default: Home },
+```
+
+**React node** -- server component JSX rendered directly:
+
+```tsx
+app: <BlogPost slug="hello-world" content={content} />,
+```
+
+The React node form enables parameterized rendering for SSG, where each entry passes different data to the same component without needing a separate module file.
+
+## Return Type of getEntries
+
+The entries function can return either a synchronous iterable or an async iterable:
+
+```typescript
+type GetEntriesResult =
+  | Iterable<EntryDefinition>
+  | AsyncIterable<EntryDefinition>;
+```
+
+This allows returning arrays, generators, or async generators:
+
+```tsx
+// Array
+export default function getEntries(): EntryDefinition[] {
+  return [{ path: "index.html", root: ..., app: ... }];
+}
+
+// Async generator
+export default async function* getEntries() {
+  yield { path: "index.html", root: ..., app: ... };
+}
+```
+
+## See Also
+
+- [Multiple Entrypoints](/funstack-static/learn/multiple-entrypoints) - Guide and examples
+- [funstackStatic()](/funstack-static/api/funstack-static) - Plugin configuration

--- a/packages/docs/src/pages/api/FunstackStatic.mdx
+++ b/packages/docs/src/pages/api/FunstackStatic.mdx
@@ -10,6 +10,12 @@ import funstackStatic from "@funstack/static";
 
 ## Usage
 
+There are two configuration modes: **single-entry** (one HTML page) and **multiple entries** (multiple HTML pages).
+
+### Single-Entry Mode
+
+Use `root` and `app` to produce a single `index.html`:
+
 ```typescript
 // vite.config.ts
 import funstackStatic from "@funstack/static";
@@ -25,13 +31,40 @@ export default defineConfig({
 });
 ```
 
+### Multiple Entries Mode
+
+Use `entries` to produce multiple HTML pages from a single project:
+
+```typescript
+// vite.config.ts
+import funstackStatic from "@funstack/static";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    funstackStatic({
+      entries: "./src/entries.tsx",
+    }),
+    react(),
+  ],
+});
+```
+
+See [Multiple Entrypoints](/funstack-static/learn/multiple-entrypoints) for a full guide.
+
 ## Options
 
-### root (required)
+The plugin accepts either `root` + `app` (single-entry) or `entries` (multiple entries). These two modes are mutually exclusive.
+
+### root
 
 **Type:** `string`
+**Required in:** single-entry mode
 
 Path to the root component file. This component wraps your entire application and defines the HTML document structure (`<html>`, `<head>`, `<body>`).
+
+Cannot be used together with `entries`.
 
 ```typescript
 funstackStatic({
@@ -57,11 +90,14 @@ export default function Root({ children }: { children: React.ReactNode }) {
 }
 ```
 
-### app (required)
+### app
 
 **Type:** `string`
+**Required in:** single-entry mode
 
 Path to the app component file. This component defines your application's content.
+
+Cannot be used together with `entries`.
 
 ```typescript
 funstackStatic({
@@ -84,6 +120,45 @@ export default function App() {
 ```
 
 **Note:** if your app has multiple pages, you can use a routing library here just like in a traditional SPA.
+
+### entries
+
+**Type:** `string`
+**Required in:** multiple entries mode
+
+Path to an entries module that exports a function returning entry definitions. Each entry produces its own HTML file.
+
+Cannot be used together with `root` or `app`.
+
+```typescript
+funstackStatic({
+  entries: "./src/entries.tsx",
+});
+```
+
+The entries module must default-export a function that returns entry definitions:
+
+```tsx
+// src/entries.tsx
+import type { EntryDefinition } from "@funstack/static/entries";
+
+export default function getEntries(): EntryDefinition[] {
+  return [
+    {
+      path: "index.html",
+      root: () => import("./root"),
+      app: () => import("./pages/Home"),
+    },
+    {
+      path: "about.html",
+      root: () => import("./root"),
+      app: () => import("./pages/About"),
+    },
+  ];
+}
+```
+
+See [Multiple Entrypoints](/funstack-static/learn/multiple-entrypoints) for details on the `EntryDefinition` type and advanced usage patterns like async generators.
 
 ### publicOutDir (optional)
 
@@ -153,6 +228,8 @@ Sentry.init({
 
 ## Full Example
 
+### Single-Entry
+
 ```typescript
 // vite.config.ts
 import { funstackStatic } from "@funstack/static";
@@ -169,6 +246,24 @@ export default defineConfig({
 });
 ```
 
+### Multiple Entries
+
+```typescript
+// vite.config.ts
+import funstackStatic from "@funstack/static";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    funstackStatic({
+      entries: "./src/entries.tsx",
+    }),
+    react(),
+  ],
+});
+```
+
 ## Vite Commands
 
 You can use the same Vite commands you would use in a normal Vite project:
@@ -180,5 +275,6 @@ You can use the same Vite commands you would use in a normal Vite project:
 ## See Also
 
 - [Getting Started](/funstack-static/getting-started) - Quick start guide
+- [Multiple Entrypoints](/funstack-static/learn/multiple-entrypoints) - Multi-page static site generation
 - [defer()](/funstack-static/api/defer) - Deferred rendering for streaming
 - [React Server Components](/funstack-static/learn/rsc) - Understanding RSC

--- a/packages/docs/src/pages/learn/MultipleEntrypoints.mdx
+++ b/packages/docs/src/pages/learn/MultipleEntrypoints.mdx
@@ -1,0 +1,246 @@
+# Multiple Entrypoints
+
+By default, FUNSTACK Static produces a single `index.html` from one `root` + `app` pair. The **multiple entries** feature lets you produce multiple HTML pages from a single project, targeting SSG (Static Site Generation) use cases where a site has distinct pages like `index.html`, `about.html`, and `blog/post-1.html`.
+
+## When to Use Multiple Entries
+
+Use the `entries` option when you want to build a **multi-page static site** where each page is a self-contained HTML document. This is different from a single-page app with client-side routing:
+
+- **Single-entry mode** (`root` + `app`): One HTML file, client-side routing between pages. Best for app-like experiences where navigation should not trigger full page reloads.
+- **Multiple entries mode** (`entries`): Multiple HTML files, each independently pre-rendered. Best for content sites (blogs, docs, marketing pages) where each page should be a standalone document.
+
+## Basic Setup
+
+### 1. Configure Vite
+
+Instead of `root` and `app`, pass an `entries` path:
+
+```typescript
+// vite.config.ts
+import funstackStatic from "@funstack/static";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    funstackStatic({
+      entries: "./src/entries.tsx",
+    }),
+    react(),
+  ],
+});
+```
+
+### 2. Create the Entries Module
+
+The entries module default-exports a function that returns an array of entry definitions:
+
+```tsx
+// src/entries.tsx
+import type { EntryDefinition } from "@funstack/static/entries";
+
+export default function getEntries(): EntryDefinition[] {
+  return [
+    {
+      path: "index.html",
+      root: () => import("./root"),
+      app: () => import("./pages/Home"),
+    },
+    {
+      path: "about.html",
+      root: () => import("./root"),
+      app: () => import("./pages/About"),
+    },
+  ];
+}
+```
+
+### 3. Create Root and Page Components
+
+The root and page components work exactly the same as in single-entry mode:
+
+```tsx
+// src/root.tsx
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="UTF-8" />
+        <title>My Site</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+```tsx
+// src/pages/Home.tsx
+export default function Home() {
+  return (
+    <main>
+      <h1>Home Page</h1>
+      <a href="/about">About</a>
+    </main>
+  );
+}
+```
+
+```tsx
+// src/pages/About.tsx
+export default function About() {
+  return (
+    <main>
+      <h1>About Page</h1>
+      <a href="/">Home</a>
+    </main>
+  );
+}
+```
+
+## EntryDefinition
+
+Each entry in the array is an `EntryDefinition` object imported from `@funstack/static/entries`:
+
+```typescript
+import type { EntryDefinition } from "@funstack/static/entries";
+```
+
+### path
+
+**Type:** `string`
+
+The output file path relative to the build output directory. Must end with `.html` and must not start with `/`.
+
+```typescript
+{
+  path: "index.html",          // -> /index.html
+  path: "about.html",          // -> /about.html
+  path: "blog/post-1.html",   // -> /blog/post-1.html
+}
+```
+
+The `path` specifies the exact output file name. The dev and preview servers handle mapping URL paths to these file names automatically (e.g., a request to `/about` finds `about.html`).
+
+### root
+
+**Type:** `MaybePromise<RootModule> | (() => MaybePromise<RootModule>)`
+
+The root component module. Accepts either a lazy import or a synchronous module object:
+
+```tsx
+// Lazy import (recommended for memory efficiency)
+root: () => import("./root"),
+
+// Synchronous module object
+import Root from "./root";
+root: { default: Root },
+```
+
+The module must have a `default` export of a component that accepts `children`.
+
+### app
+
+**Type:** `ReactNode | MaybePromise<AppModule> | (() => MaybePromise<AppModule>)`
+
+The app content for this entry. Accepts a module (sync or lazy), or a React node for direct rendering:
+
+```tsx
+// Lazy import
+app: () => import("./pages/Home"),
+
+// Synchronous module object
+import Home from "./pages/Home";
+app: { default: Home },
+
+// React node (server component JSX)
+app: <BlogPost slug="hello-world" />,
+```
+
+The React node form is especially useful for parameterized SSG, where each entry renders the same component with different data.
+
+## Advanced: Async Generators
+
+For sites with many pages generated from external data, use an async generator to stream entries without building the full array in memory:
+
+```tsx
+// src/entries.tsx
+import type { EntryDefinition } from "@funstack/static/entries";
+import Root from "./root";
+import { readdir } from "node:fs/promises";
+
+export default async function* getEntries(): AsyncGenerator<EntryDefinition> {
+  // Static pages
+  yield {
+    path: "index.html",
+    root: { default: Root },
+    app: () => import("./pages/Home"),
+  };
+
+  // Dynamic pages generated from the filesystem
+  for (const slug of await readdir("./content/blog")) {
+    const content = await loadMarkdown(`./content/blog/${slug}`);
+    yield {
+      path: `blog/${slug.replace(/\.md$/, ".html")}`,
+      root: { default: Root },
+      app: <BlogPost content={content} />,
+    };
+  }
+}
+```
+
+The entries function runs in the RSC environment at build time, so it has access to Node.js APIs like `fs`, making it straightforward to generate pages from files, a CMS, or a database.
+
+## Output Structure
+
+Given entries with paths `index.html`, `about.html`, and `blog/post-1.html`, the build produces:
+
+```
+dist/public/
+├── index.html
+├── about.html
+├── blog/
+│   └── post-1.html
+├── funstack__/
+│   └── fun:rsc-payload/
+│       ├── a1b2c3d4.txt          # RSC payload for index.html
+│       ├── e5f6g7h8.txt          # RSC payload for about.html
+│       ├── i9j0k1l2.txt          # RSC payload for blog/post-1.html
+│       └── ...                   # deferred component payloads
+└── assets/
+    └── client.js                 # Client bundle (shared)
+```
+
+All pages share the same client JavaScript bundle. Only the HTML and RSC payloads differ per entry.
+
+## Navigation Between Entries
+
+Each entry is a fully independent HTML page. Navigation between entries is a full page reload via standard `<a>` links. Client-side interactivity within each page works as usual.
+
+If you need client-side navigation between pages (SPA-style transitions), use single-entry mode with a client-side router instead.
+
+## Interaction with defer()
+
+The `defer()` function works with multiple entries. Deferred components are shared across entries via content hashing -- if multiple entries defer the same component, it is rendered once and reused.
+
+## Path Validation
+
+The build enforces these rules for entry paths:
+
+- Must end with `.html`
+- Must not start with `/` (paths are relative to the output directory)
+- Duplicate paths cause a build error
+
+## Dev and Preview Server
+
+Both the dev server (`vite dev`) and preview server (`vite preview`) handle URL-to-file mapping automatically:
+
+- `/` serves `index.html`
+- `/about` serves `about.html`, falling back to `about/index.html`
+- `/blog/post-1` serves `blog/post-1.html`, falling back to `blog/post-1/index.html`
+
+## See Also
+
+- [funstackStatic()](/funstack-static/api/funstack-static) - Configuration reference
+- [Getting Started](/funstack-static/getting-started) - Quick start guide
+- [defer()](/funstack-static/api/defer) - Deferred rendering for streaming


### PR DESCRIPTION
- Add Learn page explaining multi-page SSG with the entries option
- Add EntryDefinition API reference page
- Update funstackStatic() API docs with entries option and mutual exclusivity
- Add sidebar navigation and routes for new pages
- Mention multiple entrypoints in Getting Started guide

https://claude.ai/code/session_01FqvX3t2DVJHgxmUp6vAyZq