### PR TITLE
Update documentation URL to static.funstack.work

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A maximally minimal React framework.
 
 ### Usage
 
-**[Documentation](https://uhyo.github.io/funstack-static/)**
+**[Documentation](https://static.funstack.work/)**
 
 See [the docs project](./packages/docs/vite.config.ts) for complete usage.
 

--- a/packages/static/README.md
+++ b/packages/static/README.md
@@ -37,7 +37,7 @@ export default defineConfig({
 
 ## Documentation
 
-For detailed API documentation and guides, visit the **[Documentation](https://uhyo.github.io/funstack-static/)**.
+For detailed API documentation and guides, visit the **[Documentation](https://static.funstack.work/)**.
 
 ### :robot: FUNSTACK Static Skill
 


### PR DESCRIPTION
## Summary
Updated documentation links across the project to point to the new domain `static.funstack.work` instead of the previous GitHub Pages URL.

## Changes
- Updated documentation URL in root `README.md`
- Updated documentation URL in `packages/static/README.md`

## Details
This change migrates the documentation hosting from `uhyo.github.io/funstack-static/` to the custom domain `static.funstack.work/`. Both references in the main README and the static package README have been updated to reflect the new URL.

https://claude.ai/code/session_01WUSnCTTLWDzoJUhC4XFTCC