### PR TITLE
fix: make skill installer work without prior package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ export default defineConfig({
 
 ### :robot: FUNSTACK Static Skill
 
-FUNSTACK Static provides an Agent Skill to feed your AI agents with knowledge about this framework. After installing `@funstack/static`, run the following command to add the skill to the project:
+FUNSTACK Static provides an Agent Skill to feed your AI agents with knowledge about this framework. Run the following command to add the skill to the project:
 
 ```sh
-npx funstack-static-skill-installer
+npx -p @funstack/static funstack-static-skill-installer
 # or
-yarn funstack-static-skill-installer
+yarn dlx -p @funstack/static funstack-static-skill-installer
 # or
-pnpm funstack-static-skill-installer
+pnpm --package @funstack/static dlx funstack-static-skill-installer
 # or, if you use skills CLI (https://skills.sh/)
 npx skills add uhyo/funstack-static
 ```

--- a/packages/docs/src/pages/GettingStarted.mdx
+++ b/packages/docs/src/pages/GettingStarted.mdx
@@ -168,7 +168,11 @@ Only two files are required: `Root.tsx` and `App.tsx`. The paths to these files 
 If you use AI coding assistants like [Claude Code](https://docs.anthropic.com/en/docs/claude-code), you can install the FUNSTACK Static knowledge skill to help your AI assistant better understand the framework:
 
 ```bash
-npx funstack-static-skill-installer
+npx -p @funstack/static funstack-static-skill-installer
+# or
+yarn dlx -p @funstack/static funstack-static-skill-installer
+# or
+pnpm --package @funstack/static dlx funstack-static-skill-installer
 # or, if you use skills CLI (https://skills.sh/)
 npx skills add uhyo/funstack-static
 ```

--- a/packages/docs/src/pages/MigratingFromViteSPA.mdx
+++ b/packages/docs/src/pages/MigratingFromViteSPA.mdx
@@ -27,7 +27,7 @@ Or with pnpm:
 pnpm add @funstack/static
 ```
 
-**Hint:** at this point, a skill installer command is available to add FUNSTACK Static knowledge to your AI agents. Run `npx funstack-static-skill-installer` (or `npx skills add uhyo/funstack-static` if you use [skills CLI](https://skills.sh/)) to add the skill. Then you can ask your AI assistant for help with the migration!
+**Hint:** at this point, you can add FUNSTACK Static knowledge to your AI agents. Run `npx -p @funstack/static funstack-static-skill-installer` (or `npx skills add uhyo/funstack-static` if you use [skills CLI](https://skills.sh/)) to add the skill. Then you can ask your AI assistant for help with the migration!
 
 ## Step 2: Update Vite Config
 

--- a/packages/static/README.md
+++ b/packages/static/README.md
@@ -41,14 +41,14 @@ For detailed API documentation and guides, visit the **[Documentation](https://s
 
 ### :robot: FUNSTACK Static Skill
 
-FUNSTACK Static provides an Agent Skill to feed your AI agents with knowledge about this framework. After installing `@funstack/static`, run the following command to add the skill to the project:
+FUNSTACK Static provides an Agent Skill to feed your AI agents with knowledge about this framework. Run the following command to add the skill to the project:
 
 ```sh
-npx funstack-static-skill-installer
+npx -p @funstack/static funstack-static-skill-installer
 # or
-yarn funstack-static-skill-installer
+yarn dlx -p @funstack/static funstack-static-skill-installer
 # or
-pnpm funstack-static-skill-installer
+pnpm --package @funstack/static dlx funstack-static-skill-installer
 # or, if you use skills CLI (https://skills.sh/)
 npx skills add uhyo/funstack-static
 ```

--- a/packages/static/src/bin/skill-installer.ts
+++ b/packages/static/src/bin/skill-installer.ts
@@ -2,11 +2,15 @@
 
 import { install } from "@funstack/skill-installer";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const skillDir =
-  "./node_modules/@funstack/static/skills/funstack-static-knowledge";
-
-const resolved = path.resolve(skillDir);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Resolve relative to this script (dist/bin/) so it works
+// both when installed locally and via npx -p / pnpm dlx / yarn dlx.
+const resolved = path.resolve(
+  __dirname,
+  "../../skills/funstack-static-knowledge",
+);
 
 console.log("Installing skill from:", resolved);
 


### PR DESCRIPTION
Resolve the skills directory relative to the script itself (via
import.meta.url) instead of relative to CWD, so the installer works
when invoked through npx -p / yarn dlx / pnpm dlx without having
@funstack/static installed first.

Update all documented install commands to use the zero-install
variants and add yarn dlx / pnpm dlx equivalents.

https://claude.ai/code/session_0171KKmMhMFZuwbzbCxqgCNd