### PR TITLE
fix: abort build on rendering error instead of emitting error HTML

### DIFF
--- a/packages/static/src/ssr/entry.tsx
+++ b/packages/static/src/ssr/entry.tsx
@@ -82,7 +82,11 @@ export async function renderHTML(
       });
     }
   } catch (e) {
-    // In this case, RSC payload is still sent to client and we let client render from scratch anyway.
+    if (options.build) {
+      // In build mode, abort the build so the error is not silently swallowed.
+      throw e;
+    }
+    // In dev mode, RSC payload is still sent to client and we let client render from scratch anyway.
     // This triggers the error boundary on client side.
     status = 500;
     htmlStream = await renderToReadableStream(


### PR DESCRIPTION
Previously, when prerendering failed during build, the error was caught
and a fallback error HTML was emitted, allowing the build to complete
silently with broken output. Now the error is re-thrown in build mode so
the build fails immediately. The graceful fallback (500 status + client
re-render) is preserved for dev mode only.

https://claude.ai/code/session_01Ffzhp4zABYA1gskj9RCT9r