### PR TITLE
fix(docs): correct funstackStatic import to use default import

### DIFF
--- a/packages/docs/src/pages/GettingStarted.mdx
+++ b/packages/docs/src/pages/GettingStarted.mdx
@@ -23,7 +23,7 @@ pnpm add @funstack/static react react-dom
 Create or update your `vite.config.ts`:
 
 ```typescript
-import { funstackStatic } from "@funstack/static";
+import funstackStatic from "@funstack/static";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 

--- a/packages/docs/src/pages/Home.tsx
+++ b/packages/docs/src/pages/Home.tsx
@@ -2,7 +2,7 @@ import { CodeBlock } from "../components/CodeBlock/CodeBlock";
 import styles from "./Home.module.css";
 
 const heroCode = `// vite.config.ts
-import { funstackStatic } from "@funstack/static";
+import funstackStatic from "@funstack/static";
 
 export default {
   plugins: [

--- a/packages/docs/src/pages/MigratingFromViteSPA.mdx
+++ b/packages/docs/src/pages/MigratingFromViteSPA.mdx
@@ -34,7 +34,7 @@ pnpm add @funstack/static
 Modify your `vite.config.ts` to add the FUNSTACK Static plugin:
 
 ```typescript
-import { funstackStatic } from "@funstack/static";
+import funstackStatic from "@funstack/static";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 

--- a/packages/docs/src/pages/api/FunstackStatic.mdx
+++ b/packages/docs/src/pages/api/FunstackStatic.mdx
@@ -251,7 +251,7 @@ funstackStatic({
 
 ```typescript
 // vite.config.ts
-import { funstackStatic } from "@funstack/static";
+import funstackStatic from "@funstack/static";
 import { defineConfig } from "vite";
 
 export default defineConfig({

--- a/packages/static/skills/funstack-static-knowledge/SKILL.md
+++ b/packages/static/skills/funstack-static-knowledge/SKILL.md
@@ -16,7 +16,7 @@ FUNSTACk Static is served as a Vite plugin. See your app's `vite.config.ts` file
 ```ts
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import { funstackStatic } from "@funstack/static";
+import funstackStatic from "@funstack/static";
 
 export default defineConfig({
   plugins: [


### PR DESCRIPTION
This PR fixes incorrect named import `{ funstackStatic }` to defalt import `funstackStatic` in documentation and skill files.
The `@funstack/static` package exports `funstackStatic` as a default export, but several docs showed it as a named export.