### PR TITLE
docs: remove fsRoutes ssr:true dev-server restriction notes

### DIFF
--- a/packages/docs/src/pages/api/FunstackStatic.mdx
+++ b/packages/docs/src/pages/api/FunstackStatic.mdx
@@ -80,7 +80,7 @@ export default defineConfig({
 });
 ```
 
-`ssr: true` is required for the dev server to render pages. See [File-System Routing](/learn/file-system-routing) for a full guide.
+`ssr` is optional here, but enabling it (`ssr: true`) is recommended for SEO and faster initial load. See [File-System Routing](/learn/file-system-routing) for a full guide.
 
 ## Options
 
@@ -215,7 +215,7 @@ funstackStatic({
 - **`root`** (required) — path to the root (HTML shell) component module.
 - **`adapter`** (required) — a module that `export default`s an `FsRoutesAdapter`, given as a bare module specifier or a path relative to the Vite root. Use the bundled `@funstack/static/fs-routes/next-adapter` for the built-in Next.js-like convention, or point it at your own module for a custom one.
 
-Enable [`ssr`](#ssr-optional) alongside `fsRoutes` — it is required for the dev server to render pages and recommended in general.
+Enabling [`ssr`](#ssr-optional) alongside `fsRoutes` is optional but recommended for SEO and faster initial load.
 
 See [File-System Routing](/learn/file-system-routing) for the conventions, dynamic routes, and writing custom adapters.
 

--- a/packages/docs/src/pages/learn/FileSystemRouting.mdx
+++ b/packages/docs/src/pages/learn/FileSystemRouting.mdx
@@ -47,7 +47,7 @@ All `fsRoutes` fields are required, so each choice is explicit in your config:
 
 `fsRoutes` is mutually exclusive with the `root` + `app` (single-entry) and `entries` (multiple entries) modes.
 
-> **Enable [`ssr`](/api/funstack-static).** Pages are server components rendered through FUNSTACK Router. `ssr: true` is **required for the dev server** (`vite dev`) to render your pages — without it, the dev server can only render the app shell — and it is recommended in general for SEO and faster initial load. Production builds work with `ssr` either way. Lifting this dev-server requirement is tracked in [#124](https://github.com/uhyo/funstack-static/issues/124).
+> **Consider enabling [`ssr`](/api/funstack-static).** Pages are server components rendered through FUNSTACK Router. `ssr` is optional and works the same in dev (`vite dev`), production builds, and preview either way, but enabling it (`ssr: true`) is recommended for SEO and faster initial load.
 
 ## The Next.js-like Convention
 


### PR DESCRIPTION
## Summary

The dev-server limitation tracked in #124 — fs-routing requiring `ssr: true` to render pages in `vite dev` — has been lifted. This cleans up the docs to remove every mention of that restriction and reframes `ssr` as an optional recommendation rather than a requirement.

## Changes

- **`packages/docs/src/pages/learn/FileSystemRouting.mdx`** — the callout box no longer states `ssr: true` is "required for the dev server" or that the dev server "can only render the app shell"; dropped the link to #124. Now frames `ssr` as optional and consistent across dev / build / preview, recommended for SEO and faster initial load.
- **`packages/docs/src/pages/api/FunstackStatic.mdx`** — in both the fsRoutes-mode example and the `fsRoutes` option section, "required for the dev server to render pages" → "optional but recommended for SEO and faster initial load".

The `ssr: true` lines in the code snippets are kept as the recommended setup; only the prose claiming it's mandatory changed. Grepped the repo to confirm no other `#124` / "required for the dev" / "app shell" restriction references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYLKPC9rXbCVyDMGawSrak)_