### PR TITLE
fix: resolve outDir against Vite root in buildApp

### DIFF
--- a/packages/static/src/build/buildApp.ts
+++ b/packages/static/src/build/buildApp.ts
@@ -17,12 +17,20 @@ export async function buildApp(
 ) {
   const { config } = builder;
   // import server entry
-  const entryPath = path.join(config.environments.rsc.build.outDir, "index.js");
+  // outDir may be relative, in which case it is relative to the Vite root
+  // (not process.cwd())
+  const entryPath = path.join(
+    path.resolve(config.root, config.environments.rsc.build.outDir),
+    "index.js",
+  );
   const entry: typeof import("../rsc/entry") = await import(
     pathToFileURL(entryPath).href
   );
 
-  const baseDir = config.environments.client.build.outDir;
+  const baseDir = path.resolve(
+    config.root,
+    config.environments.client.build.outDir,
+  );
   const base = normalizeBase(config.base);
 
   async function doBuild() {


### PR DESCRIPTION
## Summary

Fixes #141.

`buildApp` used the configured `outDir` values of the `rsc` and `client` environments directly. Since `outDir` may be a relative path, these resolved against `process.cwd()` — so running `vite build` from a directory other than the Vite root (e.g. monorepo root with `--config`) could break the RSC entry import or write output to the wrong location. Both paths are now resolved with `path.resolve(config.root, outDir)`, matching what `serverPlugin` already does.

This also guarantees `BuildEntryContext.outDir` is absolute, as its documentation promises.

## Note

While verifying, I found the bug is currently masked in practice: `@vitejs/plugin-rsc` (0.5.28) rewrites every environment's `build.outDir` to an absolute path in its own `configResolved` hook. The fix is still worthwhile — it stops `buildApp` from silently depending on a dependency's internal behavior, and `path.resolve` is a no-op on already-absolute paths, so there is no behavior change today.

## Verification

- Built the example app with an explicit `root` in the Vite config while running `vite build` from a different working directory; output landed correctly under the Vite root with nothing leaked into the cwd.
- `pnpm build`, `pnpm typecheck`, `pnpm lint`, all 77 unit tests, and all 29 Playwright e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEURCLVLKQvqYUrAkqcHpE

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEURCLVLKQvqYUrAkqcHpE)_