### PR TITLE
fix: strip the fs-routes root deterministically via a required base option

### DIFF
--- a/packages/docs/src/pages/learn/FileSystemRouting.mdx
+++ b/packages/docs/src/pages/learn/FileSystemRouting.mdx
@@ -173,6 +173,8 @@ For a complete working example, see the [`example-fs-routing`](https://github.co
 
 `fsRoutes` is a convenience built on the [`entries`](/api/funstack-static) option. If you need full control, you can write the entries module by hand — globbing pages with `import.meta.glob` and deriving [entry definitions](/api/entry-definition) yourself. The `@funstack/static/fs-routes` building blocks (`createFsRoutesEntries`, `nextRoutes`) are exported for this purpose.
 
+When calling `createFsRoutesEntries` directly, also pass the routes directory as `base` — the directory your glob pattern starts with (e.g. `base: "./pages"` for `import.meta.glob("./pages/**/*.tsx")`). Without it, the routes root is inferred as the longest common directory prefix of the globbed files, which is ambiguous when every page happens to live under one shared subdirectory.
+
 ## See Also
 
 - [funstackStatic()](/api/funstack-static) - The `fsRoutes` plugin option

--- a/packages/docs/src/pages/learn/FileSystemRouting.mdx
+++ b/packages/docs/src/pages/learn/FileSystemRouting.mdx
@@ -173,7 +173,7 @@ For a complete working example, see the [`example-fs-routing`](https://github.co
 
 `fsRoutes` is a convenience built on the [`entries`](/api/funstack-static) option. If you need full control, you can write the entries module by hand — globbing pages with `import.meta.glob` and deriving [entry definitions](/api/entry-definition) yourself. The `@funstack/static/fs-routes` building blocks (`createFsRoutesEntries`, `nextRoutes`) are exported for this purpose.
 
-When calling `createFsRoutesEntries` directly, also pass the routes directory as `base` — the directory your glob pattern starts with (e.g. `base: "./pages"` for `import.meta.glob("./pages/**/*.tsx")`). Without it, the routes root is inferred as the longest common directory prefix of the globbed files, which is ambiguous when every page happens to live under one shared subdirectory.
+When calling `createFsRoutesEntries` directly, pass the routes directory as the required `base` option — the directory your glob pattern starts with (e.g. `base: "./pages"` for `import.meta.glob("./pages/**/*.tsx")`). File paths are made relative to `base` to derive the routes, and the build fails if it does not prefix every globbed file.
 
 ## See Also
 

--- a/packages/static/src/fs-routes/runtime.tsx
+++ b/packages/static/src/fs-routes/runtime.tsx
@@ -29,6 +29,18 @@ export interface CreateFsRoutesOptions {
    */
   modules: Record<string, FsRouteModule>;
   /**
+   * The routes directory that the `modules` keys are relative to — the
+   * directory your `import.meta.glob` pattern starts with, e.g. `"./pages"`
+   * or `"/src/pages"`.
+   *
+   * When provided, this prefix is stripped from every module key
+   * deterministically. When omitted, the longest common directory prefix
+   * across all keys is stripped instead; that heuristic misdetects the routes
+   * root when every page happens to live under one shared subdirectory, so
+   * passing `base` is recommended.
+   */
+  base?: string;
+  /**
    * The root (HTML shell) component. Renders the whole page
    * (`<html>…<body>{children}</body></html>`).
    */
@@ -61,13 +73,13 @@ export interface CreateFsRoutesOptions {
  *
  * const modules = import.meta.glob("./pages/**\/*.{tsx,jsx}", { eager: true });
  *
- * export default createFsRoutesEntries({ modules, root: Root });
+ * export default createFsRoutesEntries({ modules, base: "./pages", root: Root });
  * ```
  */
 export function createFsRoutesEntries(
   options: CreateFsRoutesOptions,
 ): () => GetEntriesResult {
-  const { modules, root: Root, adapter = nextRoutes() } = options;
+  const { modules, base, root: Root, adapter = nextRoutes() } = options;
 
   function buildRouteDefinitions(
     nodes: FsRouteTreeNode[],
@@ -113,7 +125,7 @@ export function createFsRoutesEntries(
     const warn = (message: string) => {
       console.warn(`[funstack] ${message}`);
     };
-    const files = modulesToRouteFiles(modules, warn);
+    const files = modulesToRouteFiles(modules, { onWarn: warn, base });
     const tree = adapter.buildRoutes(files);
     const pages = await collectStaticPaths(tree);
     for (const { urlPath, params } of pages) {

--- a/packages/static/src/fs-routes/runtime.tsx
+++ b/packages/static/src/fs-routes/runtime.tsx
@@ -33,13 +33,11 @@ export interface CreateFsRoutesOptions {
    * directory your `import.meta.glob` pattern starts with, e.g. `"./pages"`
    * or `"/src/pages"`.
    *
-   * When provided, this prefix is stripped from every module key
-   * deterministically. When omitted, the longest common directory prefix
-   * across all keys is stripped instead; that heuristic misdetects the routes
-   * root when every page happens to live under one shared subdirectory, so
-   * passing `base` is recommended.
+   * This prefix is stripped from every module key to make route paths
+   * relative to the routes directory. The build fails if it does not prefix
+   * every key.
    */
-  base?: string;
+  base: string;
   /**
    * The root (HTML shell) component. Renders the whole page
    * (`<html>…<body>{children}</body></html>`).
@@ -125,7 +123,7 @@ export function createFsRoutesEntries(
     const warn = (message: string) => {
       console.warn(`[funstack] ${message}`);
     };
-    const files = modulesToRouteFiles(modules, { onWarn: warn, base });
+    const files = modulesToRouteFiles(modules, base, warn);
     const tree = adapter.buildRoutes(files);
     const pages = await collectStaticPaths(tree);
     for (const { urlPath, params } of pages) {

--- a/packages/static/src/fs-routes/tree.test.ts
+++ b/packages/static/src/fs-routes/tree.test.ts
@@ -149,8 +149,77 @@ describe("modulesToRouteFiles", () => {
 
   it("warns when no modules are provided", () => {
     const warn = vi.fn();
-    expect(modulesToRouteFiles({}, warn)).toEqual([]);
+    expect(modulesToRouteFiles({}, { onWarn: warn })).toEqual([]);
     expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("with base, keeps a subdirectory shared by every page", () => {
+    const files = modulesToRouteFiles(
+      {
+        "./pages/blog/page.tsx": m,
+        "./pages/blog/post/page.tsx": m,
+      },
+      { base: "./pages" },
+    );
+    expect(files.map((f) => f.filePath)).toEqual([
+      "blog/page.tsx",
+      "blog/post/page.tsx",
+    ]);
+  });
+
+  it("with base, keeps the directory of a single nested page", () => {
+    const files = modulesToRouteFiles(
+      { "./pages/docs/page.tsx": m },
+      { base: "./pages" },
+    );
+    expect(files.map((f) => f.filePath)).toEqual(["docs/page.tsx"]);
+  });
+
+  it("strips a root-relative base as emitted by the plugin", () => {
+    const files = modulesToRouteFiles(
+      {
+        "/src/pages/blog/page.tsx": m,
+        "/src/pages/blog/post/page.tsx": m,
+      },
+      { base: "/src/pages" },
+    );
+    expect(files.map((f) => f.filePath)).toEqual([
+      "blog/page.tsx",
+      "blog/post/page.tsx",
+    ]);
+  });
+
+  it("matches a base written without the leading ./ of the keys", () => {
+    const files = modulesToRouteFiles(
+      { "./pages/docs/page.tsx": m },
+      { base: "pages" },
+    );
+    expect(files.map((f) => f.filePath)).toEqual(["docs/page.tsx"]);
+  });
+
+  it("ignores a trailing slash in base", () => {
+    const files = modulesToRouteFiles(
+      { "./pages/docs/page.tsx": m },
+      { base: "./pages/" },
+    );
+    expect(files.map((f) => f.filePath)).toEqual(["docs/page.tsx"]);
+  });
+
+  it("warns and falls back to the heuristic when base does not match", () => {
+    const warn = vi.fn();
+    const files = modulesToRouteFiles(
+      {
+        "./pages/page.tsx": m,
+        "./pages/about/page.tsx": m,
+      },
+      { base: "./routes", onWarn: warn },
+    );
+    expect(files.map((f) => f.filePath)).toEqual([
+      "page.tsx",
+      "about/page.tsx",
+    ]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]![0]).toMatch(/\.\/routes/);
   });
 });
 

--- a/packages/static/src/fs-routes/tree.test.ts
+++ b/packages/static/src/fs-routes/tree.test.ts
@@ -118,12 +118,15 @@ describe("collectStaticPaths", () => {
 describe("modulesToRouteFiles", () => {
   const m: FsRouteModule = { default: () => null };
 
-  it("strips a common ./pages/ prefix", () => {
-    const files = modulesToRouteFiles({
-      "./pages/page.tsx": m,
-      "./pages/about/page.tsx": m,
-      "./pages/blog/[slug]/page.tsx": m,
-    });
+  it("strips the base from every key", () => {
+    const files = modulesToRouteFiles(
+      {
+        "./pages/page.tsx": m,
+        "./pages/about/page.tsx": m,
+        "./pages/blog/[slug]/page.tsx": m,
+      },
+      "./pages",
+    );
     expect(files.map((f) => f.filePath)).toEqual([
       "page.tsx",
       "about/page.tsx",
@@ -131,35 +134,13 @@ describe("modulesToRouteFiles", () => {
     ]);
   });
 
-  it("strips an absolute root-relative prefix", () => {
-    const files = modulesToRouteFiles({
-      "/src/pages/page.tsx": m,
-      "/src/pages/about/page.tsx": m,
-    });
-    expect(files.map((f) => f.filePath)).toEqual([
-      "page.tsx",
-      "about/page.tsx",
-    ]);
-  });
-
-  it("handles a single file at the routes root", () => {
-    const files = modulesToRouteFiles({ "./pages/page.tsx": m });
-    expect(files.map((f) => f.filePath)).toEqual(["page.tsx"]);
-  });
-
-  it("warns when no modules are provided", () => {
-    const warn = vi.fn();
-    expect(modulesToRouteFiles({}, { onWarn: warn })).toEqual([]);
-    expect(warn).toHaveBeenCalledTimes(1);
-  });
-
-  it("with base, keeps a subdirectory shared by every page", () => {
+  it("keeps a subdirectory shared by every page", () => {
     const files = modulesToRouteFiles(
       {
         "./pages/blog/page.tsx": m,
         "./pages/blog/post/page.tsx": m,
       },
-      { base: "./pages" },
+      "./pages",
     );
     expect(files.map((f) => f.filePath)).toEqual([
       "blog/page.tsx",
@@ -167,10 +148,10 @@ describe("modulesToRouteFiles", () => {
     ]);
   });
 
-  it("with base, keeps the directory of a single nested page", () => {
+  it("keeps the directory of a single nested page", () => {
     const files = modulesToRouteFiles(
       { "./pages/docs/page.tsx": m },
-      { base: "./pages" },
+      "./pages",
     );
     expect(files.map((f) => f.filePath)).toEqual(["docs/page.tsx"]);
   });
@@ -181,7 +162,7 @@ describe("modulesToRouteFiles", () => {
         "/src/pages/blog/page.tsx": m,
         "/src/pages/blog/post/page.tsx": m,
       },
-      { base: "/src/pages" },
+      "/src/pages",
     );
     expect(files.map((f) => f.filePath)).toEqual([
       "blog/page.tsx",
@@ -190,36 +171,34 @@ describe("modulesToRouteFiles", () => {
   });
 
   it("matches a base written without the leading ./ of the keys", () => {
-    const files = modulesToRouteFiles(
-      { "./pages/docs/page.tsx": m },
-      { base: "pages" },
-    );
+    const files = modulesToRouteFiles({ "./pages/docs/page.tsx": m }, "pages");
     expect(files.map((f) => f.filePath)).toEqual(["docs/page.tsx"]);
   });
 
   it("ignores a trailing slash in base", () => {
     const files = modulesToRouteFiles(
       { "./pages/docs/page.tsx": m },
-      { base: "./pages/" },
+      "./pages/",
     );
     expect(files.map((f) => f.filePath)).toEqual(["docs/page.tsx"]);
   });
 
-  it("warns and falls back to the heuristic when base does not match", () => {
+  it("warns when no modules are provided", () => {
     const warn = vi.fn();
-    const files = modulesToRouteFiles(
-      {
-        "./pages/page.tsx": m,
-        "./pages/about/page.tsx": m,
-      },
-      { base: "./routes", onWarn: warn },
-    );
-    expect(files.map((f) => f.filePath)).toEqual([
-      "page.tsx",
-      "about/page.tsx",
-    ]);
+    expect(modulesToRouteFiles({}, "./pages", warn)).toEqual([]);
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0]![0]).toMatch(/\.\/routes/);
+  });
+
+  it("throws when base does not prefix every key", () => {
+    expect(() =>
+      modulesToRouteFiles(
+        {
+          "./pages/page.tsx": m,
+          "./pages/about/page.tsx": m,
+        },
+        "./routes",
+      ),
+    ).toThrow(/"\.\/routes".*import\.meta\.glob/);
   });
 });
 

--- a/packages/static/src/fs-routes/tree.ts
+++ b/packages/static/src/fs-routes/tree.ts
@@ -1,23 +1,6 @@
 import type { FsRouteFile, FsRouteModule, FsRouteTreeNode } from "./types";
 
 /**
- * Options for {@link modulesToRouteFiles}.
- */
-export interface ModulesToRouteFilesOptions {
-  /** Called with a human-readable message when something looks wrong. */
-  onWarn?: (message: string) => void;
-  /**
-   * The routes directory that glob keys are relative to, e.g. `"./pages"` or
-   * `"/src/pages"`. When provided, it is stripped from every key
-   * deterministically. When omitted (or when it does not prefix every key),
-   * the longest common directory prefix across all keys is stripped instead —
-   * a heuristic that misdetects the root when every page happens to live
-   * under one shared subdirectory.
-   */
-  base?: string;
-}
-
-/**
  * Returns the candidate `"<dir>/"` prefixes to strip for a user-provided
  * base. A base written without a leading `"./"` also matches the `"./"`-style
  * keys Vite produces for relative glob patterns.
@@ -33,15 +16,15 @@ function basePrefixes(base: string): string[] {
 /**
  * Converts the result of an eager `import.meta.glob` into route files.
  *
- * Each file's path is made relative to the routes directory: the `base`
- * option is stripped when provided, otherwise the longest common leading
- * directory prefix across all keys is stripped as a fallback heuristic.
+ * The routes directory `base` is stripped from every key so that each file's
+ * path is relative to the routes directory. Throws if `base` does not prefix
+ * every key, since route paths cannot be derived from a wrong base.
  */
 export function modulesToRouteFiles(
   modules: Record<string, FsRouteModule>,
-  options: ModulesToRouteFilesOptions = {},
+  base: string,
+  onWarn?: (message: string) => void,
 ): FsRouteFile[] {
-  const { onWarn, base } = options;
   const keys = Object.keys(modules);
   if (keys.length === 0) {
     onWarn?.(
@@ -50,38 +33,18 @@ export function modulesToRouteFiles(
     return [];
   }
 
-  if (base !== undefined) {
-    const prefix = basePrefixes(base).find((candidate) =>
-      keys.every((key) => key.startsWith(candidate)),
-    );
-    if (prefix !== undefined) {
-      return keys.map((key) => ({
-        filePath: key.slice(prefix.length),
-        module: modules[key]!,
-      }));
-    }
-    onWarn?.(
-      `base "${base}" is not a prefix of every module key; ` +
-        `falling back to common-prefix detection. ` +
-        `Pass the same directory your import.meta.glob pattern starts with.`,
-    );
-  }
-
-  // Directory segments of each key (excluding the file name).
-  const dirSegments = keys.map((key) => key.split("/").slice(0, -1));
-  let commonLength = Math.min(
-    ...dirSegments.map((segments) => segments.length),
+  const prefix = basePrefixes(base).find((candidate) =>
+    keys.every((key) => key.startsWith(candidate)),
   );
-  for (let i = 0; i < commonLength; i++) {
-    const segment = dirSegments[0]![i];
-    if (!dirSegments.every((segments) => segments[i] === segment)) {
-      commonLength = i;
-      break;
-    }
+  if (prefix === undefined) {
+    throw new Error(
+      `base "${base}" is not a prefix of every globbed module key (e.g. "${keys[0]}"). ` +
+        `Pass the directory your import.meta.glob pattern starts with.`,
+    );
   }
 
   return keys.map((key) => ({
-    filePath: key.split("/").slice(commonLength).join("/"),
+    filePath: key.slice(prefix.length),
     module: modules[key]!,
   }));
 }

--- a/packages/static/src/fs-routes/tree.ts
+++ b/packages/static/src/fs-routes/tree.ts
@@ -1,22 +1,70 @@
 import type { FsRouteFile, FsRouteModule, FsRouteTreeNode } from "./types";
 
 /**
+ * Options for {@link modulesToRouteFiles}.
+ */
+export interface ModulesToRouteFilesOptions {
+  /** Called with a human-readable message when something looks wrong. */
+  onWarn?: (message: string) => void;
+  /**
+   * The routes directory that glob keys are relative to, e.g. `"./pages"` or
+   * `"/src/pages"`. When provided, it is stripped from every key
+   * deterministically. When omitted (or when it does not prefix every key),
+   * the longest common directory prefix across all keys is stripped instead —
+   * a heuristic that misdetects the root when every page happens to live
+   * under one shared subdirectory.
+   */
+  base?: string;
+}
+
+/**
+ * Returns the candidate `"<dir>/"` prefixes to strip for a user-provided
+ * base. A base written without a leading `"./"` also matches the `"./"`-style
+ * keys Vite produces for relative glob patterns.
+ */
+function basePrefixes(base: string): string[] {
+  const prefix = `${base.replace(/\/+$/, "")}/`;
+  if (!prefix.startsWith("/") && !prefix.startsWith("./")) {
+    return [prefix, `./${prefix}`];
+  }
+  return [prefix];
+}
+
+/**
  * Converts the result of an eager `import.meta.glob` into route files.
  *
- * The longest common leading directory prefix across all keys is stripped so
- * that each file's path is relative to the routes directory, regardless of how
- * the glob was written (`"./pages/…"`, `"/src/pages/…"`, etc.).
+ * Each file's path is made relative to the routes directory: the `base`
+ * option is stripped when provided, otherwise the longest common leading
+ * directory prefix across all keys is stripped as a fallback heuristic.
  */
 export function modulesToRouteFiles(
   modules: Record<string, FsRouteModule>,
-  onWarn?: (message: string) => void,
+  options: ModulesToRouteFilesOptions = {},
 ): FsRouteFile[] {
+  const { onWarn, base } = options;
   const keys = Object.keys(modules);
   if (keys.length === 0) {
     onWarn?.(
       "createFsRoutesEntries received no modules. Did your import.meta.glob pattern match any files?",
     );
     return [];
+  }
+
+  if (base !== undefined) {
+    const prefix = basePrefixes(base).find((candidate) =>
+      keys.every((key) => key.startsWith(candidate)),
+    );
+    if (prefix !== undefined) {
+      return keys.map((key) => ({
+        filePath: key.slice(prefix.length),
+        module: modules[key]!,
+      }));
+    }
+    onWarn?.(
+      `base "${base}" is not a prefix of every module key; ` +
+        `falling back to common-prefix detection. ` +
+        `Pass the same directory your import.meta.glob pattern starts with.`,
+    );
   }
 
   // Directory segments of each key (excluding the file name).

--- a/packages/static/src/plugin/index.ts
+++ b/packages/static/src/plugin/index.ts
@@ -338,6 +338,7 @@ export default function funstackStatic(
               `const modules = import.meta.glob(${JSON.stringify(globPattern)}, { eager: true });`,
               `export default createFsRoutesEntries({`,
               `  modules,`,
+              `  base: ${JSON.stringify(globBase)},`,
               `  root: Root,`,
               `  adapter,`,
               `});`,


### PR DESCRIPTION
Closes #139

## Problem

`modulesToRouteFiles` inferred the routes root as the longest common directory prefix of the `import.meta.glob` keys. When every page happened to live under one shared subdirectory, that subdirectory was treated as part of the routes root and stripped, shifting all routes up one level:

- `{"./pages/blog/page.tsx", "./pages/blog/post/page.tsx"}` → routes `/` and `/post` instead of `/blog` and `/blog/post`
- A single nested page `{"./pages/docs/page.tsx"}` → route `/` instead of `/docs`

## Changes

- `createFsRoutesEntries` now takes a **required `base` option** — the routes directory the glob keys are relative to (e.g. `"./pages"`). The prefix is stripped deterministically; matching is lenient about a trailing slash and a missing `./`.
- The plugin's `fsRoutes` mode passes its resolved routes directory (`globBase`) as `base` in the generated `virtual:funstack/entries` module, so plugin users are unaffected.
- The common-prefix heuristic is removed entirely. A `base` that does not prefix every globbed key now fails the build with a clear error instead of silently guessing the routes root.
- Unit tests cover both reproductions from the issue, the plugin's root-relative base form, the lenient matching, and the mismatch error.
- Docs: the File-System Routing page now documents `base` for direct `createFsRoutesEntries` users.

Requiring `base` is a breaking change for direct `createFsRoutesEntries` users, but the fs-routes module is experimental and not covered by semantic versioning.

## Verification

- `pnpm typecheck`, `pnpm test:run` (81 tests), `pnpm lint`, `pnpm format:check`, `pnpm build` all pass
- fs-routing e2e suite (9 tests) passes against a production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV5Pn6mAHVvqBZHjFKUguA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EV5Pn6mAHVvqBZHjFKUguA)_