### PR TITLE
fix: set Content-Type header when preview server serves HTML

### DIFF
--- a/packages/static/src/plugin/server.ts
+++ b/packages/static/src/plugin/server.ts
@@ -54,26 +54,22 @@ export const serverPlugin = (): Plugin => {
             if (req.headers.accept?.includes("text/html")) {
               const urlPath = new URL(req.url!, `http://${req.headers.host}`)
                 .pathname;
-              const candidates = urlPathToFileCandidates(urlPath);
+              // Entry files matching the URL path, followed by the SPA
+              // fallback (index.html / index.htm) for unmatched routes.
+              const candidates = [
+                ...new Set([
+                  ...urlPathToFileCandidates(urlPath),
+                  "index.html",
+                  "index.htm",
+                ]),
+              ];
               for (const candidate of candidates) {
                 try {
                   const html = await readFile(
                     path.join(resolvedOutDir, candidate),
                     "utf-8",
                   );
-                  res.end(html);
-                  return;
-                } catch {
-                  // Try next candidate
-                }
-              }
-              // SPA fallback: try serving index.html or index.htm for unmatched routes
-              for (const indexFile of ["index.html", "index.htm"]) {
-                try {
-                  const html = await readFile(
-                    path.join(resolvedOutDir, indexFile),
-                    "utf-8",
-                  );
+                  res.setHeader("Content-Type", "text/html; charset=utf-8");
                   res.end(html);
                   return;
                 } catch {


### PR DESCRIPTION
## Problem

The preview-server middleware in `packages/static/src/plugin/server.ts` (`configurePreviewServer`) responded with `res.end(html)` without setting any `Content-Type` header — for both matched entry files and the SPA fallback. Browsers generally sniff the response as HTML, but it should be explicit (and some environments/tools won't sniff).

Fixes #142.

## Changes

- **Set an explicit `Content-Type`.** `res.setHeader("Content-Type", "text/html; charset=utf-8")` is now sent before `res.end(html)` on every served response.
- **Collapse the two lookup loops into one.** The candidate-file loop and the separate `index.html`/`index.htm` SPA-fallback loop are merged into a single deduplicated candidate list (`new Set([...urlPathToFileCandidates(urlPath), "index.html", "index.htm"])`). The `Set` avoids re-reading `index.html`/`index.htm` for the root path, where `urlPathToFileCandidates` already yields them.

## Verification

- `pnpm typecheck` ✅
- `pnpm test:run` ✅
- `pnpm lint` (oxlint) ✅
- `pnpm format:check` (prettier) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)