### PR TITLE
fix: resolve current entry for dev HMR re-fetch in multi-entry mode

### DIFF
--- a/packages/static/e2e/fixture-multi-entry/src/entries.tsx
+++ b/packages/static/e2e/fixture-multi-entry/src/entries.tsx
@@ -12,5 +12,10 @@ export default function getEntries(): EntryDefinition[] {
       root: () => import("./root"),
       app: () => import("./pages/About"),
     },
+    {
+      path: "hmr-test.html",
+      root: () => import("./root"),
+      app: () => import("./pages/HmrTest"),
+    },
   ];
 }

--- a/packages/static/e2e/fixture-multi-entry/src/pages/HmrTest.tsx
+++ b/packages/static/e2e/fixture-multi-entry/src/pages/HmrTest.tsx
@@ -1,0 +1,9 @@
+export default function HmrTest() {
+  return (
+    <main>
+      <h1>HMR Test Page</h1>
+      <p data-testid="page-id">hmr-test</p>
+      <p data-testid="hmr-content">initial content</p>
+    </main>
+  );
+}

--- a/packages/static/e2e/tests-dev/multi-entry.spec.ts
+++ b/packages/static/e2e/tests-dev/multi-entry.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "@playwright/test";
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 
 const htmlHeaders = { Accept: "text/html" };
 
@@ -74,5 +76,40 @@ test.describe("Multi-entry page rendering (dev server)", () => {
     await page.goto("/about");
     await page.waitForLoadState("networkidle");
     expect(errors).toEqual([]);
+  });
+});
+
+test.describe("Multi-entry HMR (dev server)", () => {
+  const hmrPagePath = fileURLToPath(
+    new URL("../fixture-multi-entry/src/pages/HmrTest.tsx", import.meta.url),
+  );
+
+  test("server code change re-renders the current non-first entry", async ({
+    page,
+  }) => {
+    const originalSource = await readFile(hmrPagePath, "utf-8");
+    try {
+      await page.goto("/hmr-test");
+      await expect(page.locator("h1")).toHaveText("HMR Test Page");
+      await expect(page.getByTestId("hmr-content")).toHaveText(
+        "initial content",
+      );
+
+      await writeFile(
+        hmrPagePath,
+        originalSource.replace("initial content", "updated content"),
+      );
+
+      // The edited content should appear via HMR without a page reload
+      await expect(page.getByTestId("hmr-content")).toHaveText(
+        "updated content",
+        { timeout: 15000 },
+      );
+      // The page must still show this entry's tree, not the first entry's
+      await expect(page.locator("h1")).toHaveText("HMR Test Page");
+      await expect(page.getByTestId("page-id")).toHaveText("hmr-test");
+    } finally {
+      await writeFile(hmrPagePath, originalSource);
+    }
   });
 });

--- a/packages/static/src/client/entry.tsx
+++ b/packages/static/src/client/entry.tsx
@@ -33,9 +33,12 @@ async function devMain() {
 
   // re-fetch RSC and trigger re-rendering
   async function fetchRscPayload() {
-    const payload = await createFromFetch<RscPayload>(
-      fetch(withBasePath(devMainRscPath)),
-    );
+    // Pass the current page path so the server re-renders the entry
+    // being viewed rather than the first entry
+    const rscUrl = `${withBasePath(devMainRscPath)}?path=${encodeURIComponent(
+      location.pathname,
+    )}`;
+    const payload = await createFromFetch<RscPayload>(fetch(rscUrl));
     setPayload(payload);
   }
 

--- a/packages/static/src/rsc/entry.tsx
+++ b/packages/static/src/rsc/entry.tsx
@@ -49,6 +49,20 @@ function findEntryForUrlPath(
 }
 
 /**
+ * Resolves the entry for a URL path, falling back to the index entry
+ * (SPA fallback) when no entry matches.
+ */
+function resolveEntryForUrlPath(
+  entries: EntryDefinition[],
+  urlPath: string,
+): EntryDefinition | undefined {
+  return (
+    findEntryForUrlPath(entries, urlPath) ??
+    entries.find((e) => e.path === "index.html" || e.path === "index.htm")
+  );
+}
+
+/**
  * Renders a single entry to an HTML response.
  */
 async function renderEntryToResponse(
@@ -139,14 +153,7 @@ export async function serveHTML(request: Request): Promise<Response> {
 
   const url = new URL(request.url);
   const urlPath = stripBasePath(url.pathname);
-  let entry = findEntryForUrlPath(entries, urlPath);
-
-  // SPA fallback: if no entry matched, fall back to index.html or index.htm entry
-  if (!entry) {
-    entry = entries.find(
-      (e) => e.path === "index.html" || e.path === "index.htm",
-    );
-  }
+  const entry = resolveEntryForUrlPath(entries, urlPath);
 
   if (!entry) {
     return new Response("Not Found", {
@@ -180,15 +187,20 @@ export async function serveRSC(request: Request): Promise<Response> {
   const pathname = stripBasePath(url.pathname);
   if (pathname === devMainRscPath) {
     // root RSC stream is requested (HMR re-fetch always sends full tree)
-    // For HMR, re-render the first entry (single-entry mode) or index.html entry
     const entriesStart = performance.now();
     const entries = await loadEntriesList();
     timings.push(`entries;dur=${performance.now() - entriesStart}`);
 
-    // Use the first entry for HMR re-fetch
-    const entry = entries[0];
+    // Re-render the entry for the page the client is currently viewing,
+    // passed as the `path` query parameter (with the same SPA fallback as
+    // serveHTML). Fall back to the first entry if no path was provided.
+    const pagePath = url.searchParams.get("path");
+    const entry =
+      pagePath !== null
+        ? resolveEntryForUrlPath(entries, stripBasePath(pagePath))
+        : entries[0];
     if (!entry) {
-      throw new ServeRSCError("No entries defined", 404);
+      throw new ServeRSCError("No entry found for HMR re-fetch", 404);
     }
 
     const resolveStart = performance.now();


### PR DESCRIPTION
## Problem

In dev, server-code changes trigger `rsc:update` and the client re-fetches the RSC payload from `devMainRscPath`. The server handler (`serveRSC`) always rendered `entries[0]`, so with multiple entries, editing server code while viewing any non-first page replaced the page content with the first entry's tree. This affected every fs-routes app, since fs-routes produces one entry per page.

## Fix

- **Client** (`src/client/entry.tsx`): the HMR re-fetch now includes the current page path as a `path` query parameter.
- **Server** (`src/rsc/entry.tsx`): `serveRSC` resolves that path with the existing `findEntryForUrlPath` plus the same SPA fallback as `serveHTML` (extracted into a shared `resolveEntryForUrlPath` helper). If no `path` parameter is provided, it falls back to the first entry as before.

## Tests

Added an e2e test in `e2e/tests-dev/multi-entry.spec.ts` that loads a non-first entry, edits its server component on disk, and asserts the updated content appears via HMR while the page still shows its own tree (not the first entry's). The multi-entry fixture gained a dedicated `hmr-test.html` entry so the test's file edits can't interfere with parallel tests.

Verified the test fails against the old behavior and passes with the fix. Build, typecheck, lint, unit tests, and all dev + production e2e suites pass.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfH2tK77WCGbfh24sU4yRp

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfH2tK77WCGbfh24sU4yRp)_