### PR TITLE
fix: detect destructive non-SSR mount and wrap it in error boundary

### DIFF
--- a/packages/docs/src/pages/FAQ.mdx
+++ b/packages/docs/src/pages/FAQ.mdx
@@ -1,5 +1,11 @@
 # FAQ
 
+## I'm seeing a ``The Root component renders other content next to `{children}` `` error
+
+With `ssr: false` (the default), the App is mounted into the parent element of `{children}` in your Root component, and React removes all other content from that element when mounting. This error means your Root component renders content that is silently removed this way in production builds.
+
+Make `{children}` the only content of its parent element in the Root component (for example, wrap it in a dedicated `<div>`). See [How It Works](/learn/how-it-works#keep-children-alone-in-its-parent-element) for details.
+
 ## I'm seeing a ``<link rel=preload> must have a valid `as` value`` warning
 
 This is a bug in React itself. Please wait for [the fix](https://github.com/facebook/react/pull/34760) to be released.

--- a/packages/docs/src/pages/GettingStarted.mdx
+++ b/packages/docs/src/pages/GettingStarted.mdx
@@ -65,6 +65,7 @@ The Root component:
 - is responsible for defining the shell HTML structure of your app
 - is a server component
 - **CANNOT** import client components; you could, but they are fully rendered into static HTML and never hydrated
+- must render `{children}` as the only content of its parent element (unless SSR is enabled); see [How It Works](/learn/how-it-works#keep-children-alone-in-its-parent-element)
 
 ### 3. Create Your App Component
 

--- a/packages/docs/src/pages/advanced/SSR.mdx
+++ b/packages/docs/src/pages/advanced/SSR.mdx
@@ -30,6 +30,10 @@ This improves perceived performance, especially on:
 
 The browser can start painting content as soon as the HTML arrives, while JavaScript loads in the background. Once loaded, React hydrates the existing HTML to make it interactive.
 
+### No Root Layout Constraint
+
+Without SSR, `{children}` must be the only content of its parent element in the Root component ([details](/learn/how-it-works#keep-children-alone-in-its-parent-element)). With SSR enabled, the whole document is hydrated instead of mounting the App into a container element, so this constraint does not apply.
+
 ## Cons
 
 ### Client Components Must Be SSR-Capable

--- a/packages/docs/src/pages/learn/HowItWorks.mdx
+++ b/packages/docs/src/pages/learn/HowItWorks.mdx
@@ -85,6 +85,44 @@ The Root component is special in two ways:
 
 The Root entrypoint is a FUNSTACK Static counterpart to the `index.html` file in traditional SPAs. It allows you to still leverage some of the benefits of server components for defining the HTML shell of your application.
 
+### Keep `{children}` Alone in Its Parent Element
+
+With `ssr: false` (the default), the App is mounted on the client into the parent element of `{children}`. React clears all existing content of that element when mounting, so any other content the Root component renders **in the same element** is removed from the page the moment the App mounts:
+
+```tsx
+// ❌ BAD: <header> and <footer> are removed when the App mounts
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <header>My Site</header>
+        {children}
+        <footer>All rights reserved.</footer>
+      </body>
+    </html>
+  );
+}
+```
+
+To avoid this, make `{children}` the only content of its parent element. Static content is safe anywhere else:
+
+```tsx
+// ✅ GOOD: {children} is the only content of its parent <div>
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <header>My Site</header>
+        <div>{children}</div>
+        <footer>All rights reserved.</footer>
+      </body>
+    </html>
+  );
+}
+```
+
+FUNSTACK Static reports a console error, both in development and in production builds, when it detects content that would be removed by the mount. If you want such content to survive, you can also move it into the App component, or enable [`ssr: true`](/advanced/ssr) — with SSR the whole document is hydrated and this constraint does not apply.
+
 ## Server-Side Rendering
 
 By default, FUNSTACK Static only renders the Root shell to HTML. The App component is rendered client-side from its RSC payload. This behavior keeps the initial HTML small and fast to deliver.

--- a/packages/static/e2e/fixture-multi-entry/src/entries.tsx
+++ b/packages/static/e2e/fixture-multi-entry/src/entries.tsx
@@ -17,5 +17,10 @@ export default function getEntries(): EntryDefinition[] {
       root: () => import("./root"),
       app: () => import("./pages/HmrTest"),
     },
+    {
+      path: "destructive.html",
+      root: () => import("./root-destructive"),
+      app: () => import("./pages/Destructive"),
+    },
   ];
 }

--- a/packages/static/e2e/fixture-multi-entry/src/pages/Destructive.tsx
+++ b/packages/static/e2e/fixture-multi-entry/src/pages/Destructive.tsx
@@ -1,0 +1,8 @@
+export default function Destructive() {
+  return (
+    <main>
+      <h1>Destructive Page</h1>
+      <p data-testid="page-id">destructive</p>
+    </main>
+  );
+}

--- a/packages/static/e2e/fixture-multi-entry/src/root-destructive.tsx
+++ b/packages/static/e2e/fixture-multi-entry/src/root-destructive.tsx
@@ -1,0 +1,21 @@
+// A Root that violates the "keep {children} alone in its parent element"
+// constraint: the <header> shares <body> with the app mount point, so the
+// production client mount destroys it and a console error is reported.
+export default function RootDestructive({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="UTF-8" />
+        <title>Destructive Mount Fixture</title>
+      </head>
+      <body>
+        <header data-testid="doomed-header">Static Header</header>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/packages/static/e2e/tests-dev/multi-entry.spec.ts
+++ b/packages/static/e2e/tests-dev/multi-entry.spec.ts
@@ -79,6 +79,48 @@ test.describe("Multi-entry page rendering (dev server)", () => {
   });
 });
 
+test.describe("Destructive mount detection (dev server)", () => {
+  test("warns about Root content that a production mount would destroy", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto("/destructive");
+    await expect(page.locator("h1")).toHaveText("Destructive Page");
+
+    // In dev the full tree (including Root) is rendered by React, so the
+    // content survives — the console error is the only signal of the problem
+    await expect(page.getByTestId("doomed-header")).toBeVisible();
+
+    const warning = consoleErrors.find((m) => m.includes("[@funstack/static]"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("<header>");
+  });
+
+  test("does not warn when {children} is alone in its parent", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto("/");
+    await expect(page.locator("h1")).toHaveText("Home Page");
+
+    expect(
+      consoleErrors.filter((m) => m.includes("[@funstack/static]")),
+    ).toEqual([]);
+  });
+});
+
 test.describe("Multi-entry HMR (dev server)", () => {
   const hmrPagePath = fileURLToPath(
     new URL("../fixture-multi-entry/src/pages/HmrTest.tsx", import.meta.url),

--- a/packages/static/e2e/tests/multi-entry.spec.ts
+++ b/packages/static/e2e/tests/multi-entry.spec.ts
@@ -92,3 +92,44 @@ test.describe("Multi-entry page rendering", () => {
     expect(errors).toEqual([]);
   });
 });
+
+test.describe("Destructive mount detection", () => {
+  test("warns when Root content shares the mount container", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto("/destructive");
+    await expect(page.locator("h1")).toHaveText("Destructive Page");
+
+    // The <header> shares <body> with the mount point, so mounting removed it
+    await expect(page.getByTestId("doomed-header")).toHaveCount(0);
+
+    const warning = consoleErrors.find((m) => m.includes("[@funstack/static]"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("<header>");
+  });
+
+  test("does not warn when {children} is alone in its parent", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto("/");
+    await expect(page.locator("h1")).toHaveText("Home Page");
+
+    expect(
+      consoleErrors.filter((m) => m.includes("[@funstack/static]")),
+    ).toEqual([]);
+  });
+});

--- a/packages/static/skills/funstack-static-knowledge/SKILL.md
+++ b/packages/static/skills/funstack-static-knowledge/SKILL.md
@@ -31,6 +31,8 @@ export default defineConfig({
 
 **Entrypoint.** Here, the `root` option points to the Root component of your application which is responsible for the HTML shell of your application. The `app` option points to the main App component which is the entrypoint for your application's UI.
 
+**Root layout constraint.** Unless the `ssr` option is enabled, the Root component must render `{children}` as the only content of its parent element. The App is mounted into that parent element on the client, which removes any other content from it. Wrap `{children}` in a dedicated element (e.g. `<div>{children}</div>`) if the Root renders other content next to it.
+
 **Server and Client Components.** The entrypoint components (Root and App) are **server components**. FUNSTACK Static follows React's conventions for Server and Client Components; the entrypoint is executed as a Server module. Modules marked with the `"use client"` directive are executed as Client modules. Server modules can import both Server and Client modules, while Client modules can only import other Client modules.
 
 **Server Actions.** Note that Server Actions (`"use server"`) are **NOT** supported in FUNSTACK Static, as there is no server runtime deployed.

--- a/packages/static/src/client/entry.tsx
+++ b/packages/static/src/client/entry.tsx
@@ -12,6 +12,7 @@ import { GlobalErrorBoundary } from "./error-boundary";
 import type { RscPayload } from "../rsc/entry";
 import { devMainRscPath } from "../rsc/request";
 import { appClientManifestVar, type AppClientManifest } from "./globals";
+import { findAppMarker, warnIfDestructiveMount } from "./mount-validation";
 import { withBasePath } from "../util/basePath";
 
 import { ssr as ssrEnabled } from "virtual:funstack/config";
@@ -59,7 +60,15 @@ async function devMain() {
   } else if (ssrEnabled) {
     hydrateRoot(document, browserRoot);
   } else {
-    // SSR off: Root shell is static HTML, mount App client-side
+    // SSR off: Root shell is static HTML, mount App client-side.
+    // The served shell has the same shape as the production build
+    // (marker span inside its container), so validate it before React
+    // replaces the document — this surfaces in dev the content that a
+    // production mount would destroy.
+    const appMarker = findAppMarker();
+    if (appMarker) {
+      warnIfDestructiveMount(appMarker);
+    }
     createRoot(document).render(browserRoot);
   }
 
@@ -94,8 +103,16 @@ async function prodMain() {
 
     hydrateRoot(document, browserRoot);
   } else {
-    // SSR off: Root shell only, mount App client-side
-    const browserRoot = <BrowserRoot />;
+    // SSR off: Root shell only, mount App client-side.
+    // The error boundary is embedded because the mount point is an inner
+    // element, where the document-level fallback's <html> would be invalid.
+    const browserRoot = (
+      <React.StrictMode>
+        <GlobalErrorBoundary embedded>
+          <BrowserRoot />
+        </GlobalErrorBoundary>
+      </React.StrictMode>
+    );
     const appRootId = manifest.marker!;
 
     const appMarker = document.getElementById(appRootId);
@@ -110,6 +127,7 @@ async function prodMain() {
         `App root element has no parent element. This is likely a bug.`,
       );
     }
+    warnIfDestructiveMount(appMarker);
     appMarker.remove();
 
     createRoot(appRoot).render(browserRoot);

--- a/packages/static/src/client/error-boundary.tsx
+++ b/packages/static/src/client/error-boundary.tsx
@@ -5,47 +5,73 @@ import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 
 /**
  * Whole-page error boundary for unexpected errors during development
+ *
+ * With `embedded`, the fallback is rendered without the `<html>`/`<body>`
+ * wrapper, for roots mounted inside an element rather than at the document.
  */
-export const GlobalErrorBoundary: React.FC<React.PropsWithChildren> = (
-  props,
-) => {
+export const GlobalErrorBoundary: React.FC<
+  React.PropsWithChildren<{ embedded?: boolean }>
+> = (props) => {
   return (
-    <ErrorBoundary FallbackComponent={Fallback}>{props.children}</ErrorBoundary>
+    <ErrorBoundary
+      FallbackComponent={props.embedded ? EmbeddedFallback : Fallback}
+    >
+      {props.children}
+    </ErrorBoundary>
   );
 };
 
-const Fallback: React.FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
+const fallbackStyle: React.CSSProperties = {
+  height: "100vh",
+  display: "flex",
+  flexDirection: "column",
+  placeContent: "center",
+  placeItems: "center",
+  fontSize: "24px",
+  fontWeight: 400,
+  lineHeight: "1.5em",
+};
+
+const FallbackContent: React.FC<FallbackProps> = ({
+  error,
+  resetErrorBoundary,
+}) => {
   const errorMessage = error instanceof Error ? error.message : String(error);
+  return (
+    <>
+      <h1>Caught an unexpected error</h1>
+      <p>See the console for details.</p>
+      <pre>Error: {errorMessage}</pre>
+      <button
+        onClick={() => {
+          startTransition(() => {
+            resetErrorBoundary();
+          });
+        }}
+      >
+        Reset
+      </button>
+    </>
+  );
+};
+
+const Fallback: React.FC<FallbackProps> = (props) => {
   return (
     <html>
       <head>
         <title>Unexpected Error</title>
       </head>
-      <body
-        style={{
-          height: "100vh",
-          display: "flex",
-          flexDirection: "column",
-          placeContent: "center",
-          placeItems: "center",
-          fontSize: "24px",
-          fontWeight: 400,
-          lineHeight: "1.5em",
-        }}
-      >
-        <h1>Caught an unexpected error</h1>
-        <p>See the console for details.</p>
-        <pre>Error: {errorMessage}</pre>
-        <button
-          onClick={() => {
-            startTransition(() => {
-              resetErrorBoundary();
-            });
-          }}
-        >
-          Reset
-        </button>
+      <body style={fallbackStyle}>
+        <FallbackContent {...props} />
       </body>
     </html>
+  );
+};
+
+const EmbeddedFallback: React.FC<FallbackProps> = (props) => {
+  return (
+    <div style={fallbackStyle}>
+      <FallbackContent {...props} />
+    </div>
   );
 };

--- a/packages/static/src/client/mount-validation.test.ts
+++ b/packages/static/src/client/mount-validation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectDestructiveSiblings,
+  describeNode,
+  type ContainerLike,
+  type NodeLike,
+} from "./mount-validation";
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+const COMMENT_NODE = 8;
+
+function element(tagName: string): NodeLike {
+  return {
+    nodeType: ELEMENT_NODE,
+    nodeName: tagName.toUpperCase(),
+    textContent: "",
+  };
+}
+
+function text(content: string): NodeLike {
+  return {
+    nodeType: TEXT_NODE,
+    nodeName: "#text",
+    textContent: content,
+  };
+}
+
+function comment(content: string): NodeLike {
+  return {
+    nodeType: COMMENT_NODE,
+    nodeName: "#comment",
+    textContent: content,
+  };
+}
+
+function container(...childNodes: NodeLike[]): ContainerLike {
+  return {
+    nodeType: ELEMENT_NODE,
+    nodeName: "BODY",
+    textContent: "",
+    childNodes,
+  };
+}
+
+const marker = element("span");
+
+describe("collectDestructiveSiblings", () => {
+  it("returns nothing when the marker is the only child", () => {
+    expect(collectDestructiveSiblings(container(marker), marker)).toEqual([]);
+  });
+
+  it("ignores whitespace-only text nodes", () => {
+    const c = container(text("\n  "), marker, text("\t\n"));
+    expect(collectDestructiveSiblings(c, marker)).toEqual([]);
+  });
+
+  it("ignores comment nodes", () => {
+    const c = container(comment("$"), marker, comment("/$"));
+    expect(collectDestructiveSiblings(c, marker)).toEqual([]);
+  });
+
+  it("ignores script elements", () => {
+    // the framework emits bootstrap / RSC payload scripts next to the marker
+    const c = container(marker, element("script"), element("script"));
+    expect(collectDestructiveSiblings(c, marker)).toEqual([]);
+  });
+
+  it("collects element siblings", () => {
+    const header = element("header");
+    const footer = element("footer");
+    const c = container(header, marker, footer);
+    expect(collectDestructiveSiblings(c, marker)).toEqual([header, footer]);
+  });
+
+  it("collects non-whitespace text siblings", () => {
+    const greeting = text("Hello");
+    const c = container(greeting, marker);
+    expect(collectDestructiveSiblings(c, marker)).toEqual([greeting]);
+  });
+
+  it("collects siblings mixed with ignorable nodes", () => {
+    const nav = element("nav");
+    const c = container(
+      text("\n"),
+      nav,
+      comment("x"),
+      marker,
+      element("script"),
+    );
+    expect(collectDestructiveSiblings(c, marker)).toEqual([nav]);
+  });
+});
+
+describe("describeNode", () => {
+  it("describes elements by tag name", () => {
+    expect(describeNode(element("header"))).toBe("<header>");
+  });
+
+  it("describes text nodes by quoted content", () => {
+    expect(describeNode(text("  Hello  "))).toBe('"Hello"');
+  });
+
+  it("truncates long text content", () => {
+    expect(describeNode(text("a".repeat(50)))).toBe(`"${"a".repeat(30)}…"`);
+  });
+});

--- a/packages/static/src/client/mount-validation.ts
+++ b/packages/static/src/client/mount-validation.ts
@@ -1,0 +1,91 @@
+import { appMarkerPrefix } from "../rsc/marker";
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+
+/**
+ * Structural subset of DOM Node used by the validation logic,
+ * allowing unit tests to run without a DOM implementation.
+ */
+export interface NodeLike {
+  readonly nodeType: number;
+  readonly nodeName: string;
+  readonly textContent: string | null;
+}
+
+export interface ContainerLike extends NodeLike {
+  readonly childNodes: Iterable<NodeLike>;
+}
+
+/**
+ * Collects the container's child nodes that would be destroyed by mounting
+ * the App into the container (React clears all existing children of the
+ * container on the first render).
+ *
+ * Nodes that are safe to lose are excluded:
+ * - the app marker itself
+ * - whitespace-only text nodes
+ * - non-element, non-text nodes (comments, doctypes, ...)
+ * - `<script>` elements: the framework itself emits scripts next to the
+ *   marker (bootstrap scripts, injected RSC payload chunks), and they have
+ *   already executed by mount time
+ */
+export function collectDestructiveSiblings(
+  container: ContainerLike,
+  marker: NodeLike,
+): NodeLike[] {
+  return Array.from(container.childNodes).filter((node) => {
+    if (node === marker) {
+      return false;
+    }
+    switch (node.nodeType) {
+      case ELEMENT_NODE:
+        return node.nodeName !== "SCRIPT";
+      case TEXT_NODE:
+        return node.textContent !== null && node.textContent.trim() !== "";
+      default:
+        return false;
+    }
+  });
+}
+
+export function describeNode(node: NodeLike): string {
+  if (node.nodeType === TEXT_NODE) {
+    const text = (node.textContent ?? "").trim();
+    return JSON.stringify(text.length > 30 ? `${text.slice(0, 30)}…` : text);
+  }
+  return `<${node.nodeName.toLowerCase()}>`;
+}
+
+/**
+ * Finds the app marker element in the current document, if any.
+ * Used in dev mode where the marker id is not passed to the client;
+ * the served shell HTML is inspected before React replaces the document.
+ */
+export function findAppMarker(): Element | null {
+  return document.querySelector(`[id^="${appMarkerPrefix}"]`);
+}
+
+/**
+ * Warns when mounting the App into the marker's parent element would
+ * destroy other content the Root component rendered there.
+ */
+export function warnIfDestructiveMount(appMarker: Element): void {
+  const container = appMarker.parentElement;
+  if (!container) {
+    return;
+  }
+  const destroyed = collectDestructiveSiblings(container, appMarker);
+  if (destroyed.length === 0) {
+    return;
+  }
+  console.error(
+    `[@funstack/static] The Root component renders other content next to {children} inside <${container.nodeName.toLowerCase()}>: ${destroyed
+      .map(describeNode)
+      .join(", ")}.\n` +
+      "With `ssr: false`, the App is mounted into the parent element of {children}, " +
+      "and React removes all other content from that element when the production build runs in the browser.\n" +
+      "Make {children} the only content of its parent element in Root, move the content into the App, or enable `ssr: true`.\n" +
+      "See https://static.funstack.work/learn/how-it-works#keep-children-alone-in-its-parent-element for details.",
+  );
+}

--- a/packages/static/src/rsc/marker.ts
+++ b/packages/static/src/rsc/marker.ts
@@ -1,11 +1,11 @@
 /**
  * Prefix of marker for App entry point.
  */
-const markerPrefix = "__FUNSTACK_APP_ENTRY__";
+export const appMarkerPrefix = "__FUNSTACK_APP_ENTRY__";
 
 /**
  * Generates an HTML ID for marking App entry point.
  */
 export function generateAppMarker(): string {
-  return `${markerPrefix}${crypto.randomUUID()}`;
+  return `${appMarkerPrefix}${crypto.randomUUID()}`;
 }


### PR DESCRIPTION
Closes #143

## Problem

With `ssr: false`, the App is mounted into the parent element of `{children}` in Root, and React clears all other content of that element on the first render. Content the Root rendered next to `{children}` was silently wiped in production builds while surviving in dev (where the full tree is rendered by React). Additionally, the prod non-SSR mount path was the only one of the four mount paths without `GlobalErrorBoundary` and `StrictMode`.

Per discussion, this PR takes the documentation + runtime validation approach rather than introducing a framework-owned wrapper element.

## Changes

### Runtime validation (`src/client/mount-validation.ts`)

- Before mounting, the marker's container is inspected and a `console.error` is reported listing the content that the mount destroys, with a link to the docs. The mount still proceeds (warning, not a hard failure, since the check runs in end users' browsers).
- The check also runs in **dev**: the served shell HTML has the same shape as the production build (marker span inside its container), so it is validated before `createRoot(document)` replaces the document. The marker is located by its id prefix, so no manifest plumbing is needed. This surfaces the problem on every dev page load, closing the dev/prod divergence.
- Whitespace-only text, comments, and `<script>` elements are exempt — the framework itself emits bootstrap/RSC-payload scripts next to the marker when Root uses `<body>{children}</body>`.
- The core logic is DOM-agnostic (structural types) and unit-tested without a DOM implementation.

### Error boundary / StrictMode

- The prod non-SSR mount is now wrapped in `<StrictMode><GlobalErrorBoundary>` like the other three paths.
- `GlobalErrorBoundary` gained an `embedded` prop: the existing fallback renders a full `<html><body>` document, which would be invalid when mounted into an inner container element, so the embedded variant renders the same content in a `<div>` instead.

### Docs

- New "Keep `{children}` Alone in Its Parent Element" section in How It Works (linked from the console error), a Getting Started bullet, a "No Root Layout Constraint" pro on the SSR page, a FAQ entry keyed to the error message, and a note in the bundled knowledge skill.
- All pre-existing Root examples in the docs already comply.

### Tests

- 10 new unit tests for the validation logic.
- New `destructive.html` entry in the multi-entry e2e fixture with a violating Root:
  - prod suite asserts the sibling content is actually destroyed and the warning fires;
  - dev suite asserts the content survives but the warning still fires;
  - both assert compliant Roots produce no warning.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean
- Unit tests: 91 passed
- E2E: 31/31 (build/preview) and 28/28 (dev server) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HADYAC46o2XCQPkCpavDyt

---
_Generated by [Claude Code](https://claude.ai/code/session_01HADYAC46o2XCQPkCpavDyt)_