### PR TITLE
fix: buffer rsc:update payloads arriving before dev client mounts

### DIFF
--- a/packages/static/src/client/entry.tsx
+++ b/packages/static/src/client/entry.tsx
@@ -18,7 +18,10 @@ import { withBasePath } from "../util/basePath";
 import { ssr as ssrEnabled } from "virtual:funstack/config";
 
 async function devMain() {
-  let setPayload: (v: RscPayload) => void;
+  let setPayload: ((v: RscPayload) => void) | undefined;
+  // Holds an update that arrived before the component mounted; the mount
+  // effect applies it so early rsc:update events are not dropped.
+  let pendingPayload: RscPayload | undefined;
 
   const initialPayload = await createFromReadableStream<RscPayload>(rscStream);
 
@@ -27,6 +30,11 @@ async function devMain() {
 
     useEffect(() => {
       setPayload = (v) => startTransition(() => setPayload_(v));
+      if (pendingPayload !== undefined) {
+        const payload = pendingPayload;
+        pendingPayload = undefined;
+        setPayload(payload);
+      }
     }, [setPayload_]);
 
     return payload.root;
@@ -40,7 +48,11 @@ async function devMain() {
       location.pathname,
     )}`;
     const payload = await createFromFetch<RscPayload>(fetch(rscUrl));
-    setPayload(payload);
+    if (setPayload) {
+      setPayload(payload);
+    } else {
+      pendingPayload = payload;
+    }
   }
 
   const browserRoot = (

--- a/packages/static/src/client/entry.tsx
+++ b/packages/static/src/client/entry.tsx
@@ -18,10 +18,12 @@ import { withBasePath } from "../util/basePath";
 import { ssr as ssrEnabled } from "virtual:funstack/config";
 
 async function devMain() {
-  let setPayload: ((v: RscPayload) => void) | undefined;
   // Holds an update that arrived before the component mounted; the mount
   // effect applies it so early rsc:update events are not dropped.
   let pendingPayload: RscPayload | undefined;
+  let setPayload: (v: RscPayload) => void = (v) => {
+    pendingPayload = v;
+  };
 
   const initialPayload = await createFromReadableStream<RscPayload>(rscStream);
 
@@ -48,11 +50,7 @@ async function devMain() {
       location.pathname,
     )}`;
     const payload = await createFromFetch<RscPayload>(fetch(rscUrl));
-    if (setPayload) {
-      setPayload(payload);
-    } else {
-      pendingPayload = payload;
-    }
+    setPayload(payload);
   }
 
   const browserRoot = (


### PR DESCRIPTION
## Summary

Fixes #145.

In `devMain` (`packages/static/src/client/entry.tsx`), the `rsc:update` HMR listener is registered immediately, but `setPayload` was only assigned inside the component's mount effect. An update event arriving before the first effect ran (e.g. a server-code edit racing initial render, or a slow mount on the SSR failure path) called `setPayload` while it was still `undefined`, throwing a `TypeError` and dropping the update.

## Changes

- `fetchRscPayload` now checks whether `setPayload` is assigned; if not, the fetched payload is stored in a `pendingPayload` variable instead of crashing.
- The mount effect applies any pending payload right after assigning `setPayload`, so early updates are rendered rather than dropped.

## Testing

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:run` (102 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAcPFym3wyHJQyMb2FdgqT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAcPFym3wyHJQyMb2FdgqT)_