### PR TITLE
fix: avoid buffering RSC payloads via unused tee branches in renderHTML

### DIFF
--- a/packages/static/src/ssr/entry.tsx
+++ b/packages/static/src/ssr/entry.tsx
@@ -21,13 +21,21 @@ export async function renderHTML(
     clientRscStream?: ReadableStream<Uint8Array>;
   },
 ): Promise<{ stream: ReadableStream<Uint8Array>; status?: number }> {
-  const [rscStream1, rscStream2] = rscStream.tee();
+  // Tee only when the second branch is actually consumed (dev without a
+  // separate client RSC stream). An unread tee branch buffers the entire
+  // RSC payload in memory, so skip teeing in build mode and in dev when
+  // `clientRscStream` is injected instead.
+  let ssrRscStream = rscStream;
+  let inlineRscStream = options.clientRscStream;
+  if (!options.build && inlineRscStream === undefined) {
+    [ssrRscStream, inlineRscStream] = rscStream.tee();
+  }
 
   let payload: Promise<RscPayload> | undefined;
   function SsrRoot() {
     // Tip: calling `createFromReadableStream` inside a component
     // makes `preinit`/`preload` work properly.
-    payload ??= createFromReadableStream<RscPayload>(rscStream1);
+    payload ??= createFromReadableStream<RscPayload>(ssrRscStream);
     if (options.build) {
       preload(rscPayloadPlaceholder, {
         crossOrigin: "anonymous",
@@ -109,10 +117,9 @@ export async function renderHTML(
   // In dev: always inject (client reads from inline stream).
   // In build+SSR: skip (HTML already has full content, client hydrates directly).
   // In build+no-SSR: skip (client fetches RSC from separate file).
-  if (!options.build) {
-    const streamToInject = options.clientRscStream ?? rscStream2;
+  if (!options.build && inlineRscStream !== undefined) {
     responseStream = responseStream.pipeThrough(
-      injectRSCPayload(streamToInject, {
+      injectRSCPayload(inlineRscStream, {
         nonce: options?.nonce,
       }),
     );


### PR DESCRIPTION
Closes #146

## Problem

`renderHTML` in `packages/static/src/ssr/entry.tsx` unconditionally teed the incoming RSC stream, but the second branch was only consumed in dev mode when no `clientRscStream` was provided. In two cases the branch was never read or cancelled:

- **build mode** (`options.build === true`): the payload injection step is skipped entirely;
- **dev non-SSR** (`clientRscStream` provided): the shell stream's second branch was unused.

An unread `tee()` branch causes the stream implementation to queue every chunk for it without bound, so the entire RSC payload was buffered in memory per render (per entry during builds).

## Fix

Only tee the stream when the inline injection branch will actually be consumed (dev mode without a separate `clientRscStream`). Otherwise the original stream is passed directly to `createFromReadableStream`, and the injected stream (if any) is the caller-provided `clientRscStream`.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test:run` — all pass
- `pnpm test:e2e` (31 tests) and `pnpm test:e2e:dev` (28 tests) — all pass, covering build+SSR, build+no-SSR, and both dev modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMVhUo2qQedCq79R4Ks6zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMVhUo2qQedCq79R4Ks6zh)_