### PR TITLE
fix: render SSR-enabled build entries once by teeing the RSC stream

### DIFF
--- a/packages/static/src/rsc/entry.tsx
+++ b/packages/static/src/rsc/entry.tsx
@@ -293,13 +293,12 @@ export async function build() {
     let appRscStream: ReadableStream<Uint8Array>;
 
     if (ssrEnabled) {
-      // SSR on: both streams have full tree
-      rootRscStream = renderToReadableStream<RscPayload>({
+      // SSR on: render the full tree once and tee the stream — one branch
+      // for SSR HTML, one for the app RSC payload. Rendering twice would
+      // execute every server component (and defer()) twice per entry (#147).
+      [rootRscStream, appRscStream] = renderToReadableStream<RscPayload>({
         root: <Root>{appNode}</Root>,
-      });
-      appRscStream = renderToReadableStream<RscPayload>({
-        root: <Root>{appNode}</Root>,
-      });
+      }).tee();
     } else {
       // SSR off: root stream has shell, app stream has App only
       rootRscStream = renderToReadableStream<RscPayload>({


### PR DESCRIPTION
## Summary

Fixes #147.

When `ssr` is enabled, `build()` in `packages/static/src/rsc/entry.tsx` rendered the identical element through two separate `renderToReadableStream` calls — one stream fed to `renderHTML` for SSR, the other written as the app RSC payload. As a result:

- every server component executed twice per entry (double data fetching / build work);
- every `defer()` call ran twice, registering duplicate registry entries whose payloads were both fully rendered (content hashing collapsed the duplicates to the same output file, hiding the waste but not avoiding it).

## Change

Render the full tree once and `tee()` the resulting stream — one branch goes to `renderHTML` for SSR, the other becomes the app RSC payload. This halves build-time rendering per SSR entry and guarantees both consumers see byte-identical streams.

The `tee()`'d payload branch simply buffers while `renderHTML` drains the SSR branch; it is fully drained to a string shortly after in `buildApp.ts`, so there is no unbounded-buffering concern at build time. The non-SSR path is unchanged (its two streams render genuinely different trees). Dev-server rendering already used a single stream.

## Testing

- `pnpm build` and `pnpm typecheck` pass
- `pnpm test:run` — 102 unit tests pass
- `pnpm test:e2e` — all 31 e2e tests pass, including the `ssr-defer` suite which exercises SSR builds with `defer()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShuMmxpPtcxZrHMQZdbq2a

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShuMmxpPtcxZrHMQZdbq2a)_