### PR TITLE
fix: build package before running its own e2e tests

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -22,11 +22,11 @@
       "outputs": []
     },
     "test:e2e": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["build", "^build"],
       "outputs": []
     },
     "test:e2e:dev": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["build", "^build"],
       "outputs": []
     }
   }


### PR DESCRIPTION
## Problem

The `e2e-vite7` CI job on master failed intermittently ([example run](https://github.com/uhyo/funstack-static/actions/runs/29885329482)) with:

> `Failed to resolve entry for package "@funstack/static"` while loading `e2e/fixture/vite.config.ts`

## Root cause

In `turbo.json`, `test:e2e` / `test:e2e:dev` only declared `dependsOn: ["^build"]`, which covers upstream packages' builds but **not the package's own build**. Turbo therefore runs `@funstack/static#build` and `@funstack/static#test:e2e` concurrently, and tsdown cleans `dist/` while the Playwright webServer is resolving `@funstack/static` (the e2e fixtures import from `dist/` via package exports).

The regular `ci` job dodges this because its earlier `pnpm run build` step primes the Turbo cache, making the build task an instant replay during `test:e2e`. The `e2e-vite7` job builds with `pnpm --filter @funstack/static build`, which bypasses Turbo's cache, so `turbo run test:e2e` re-executes the real build in parallel with the tests — a timing-dependent race.

## Fix

Add the package's own `build` task to `dependsOn` for `test:e2e` and `test:e2e:dev`, so the build is always ordered before the e2e tests. Verified with `turbo run test:e2e --dry=json` that `@funstack/static#test:e2e` now depends on `@funstack/static#build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZUuLgc4ndfHC8GT7JWDv2

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZUuLgc4ndfHC8GT7JWDv2)_